### PR TITLE
Make print's python3 compatible.

### DIFF
--- a/multigrid/variable_coeff_MG.py
+++ b/multigrid/variable_coeff_MG.py
@@ -77,10 +77,10 @@ class _EdgeCoeffs:
         c_edge_coeffs.y = c_eta_y*fg.dy**2/cg.dy**2
 
 
-        print "restrict: ", cg.nx
-        print c_eta_x
-        print c_eta_y
-        print " "
+        print("restrict: ", cg.nx)
+        print(c_eta_x)
+        print(c_eta_y)
+        print(" ")
         
         return c_edge_coeffs
 
@@ -127,18 +127,18 @@ class VarCoeffCCMG2d(MG.CellCenterMG2d):
         c = self.grids[self.nlevels-1].get_var("coeffs")
         c[:,:] = coeffs.copy()
         
-        print "original: "
-        print c
-        print " "
+        print("original: ")
+        print(c)
+        print(" ")
 
         self.grids[self.nlevels-1].fill_BC("coeffs")
 
         # put the coefficients on edges
         self.edge_coeffs.insert(0, _EdgeCoeffs(self.grids[self.nlevels-1].grid, c))
 
-        print self.edge_coeffs[0].x
-        print self.edge_coeffs[0].y
-        print " "
+        print(self.edge_coeffs[0].x)
+        print(self.edge_coeffs[0].y)
+        print(" ")
 
         n = self.nlevels-2
         while n >= 0:
@@ -154,7 +154,7 @@ class VarCoeffCCMG2d(MG.CellCenterMG2d):
             self.grids[n].fill_BC("coeffs")
 
             # put the coefficients on edges
-            print type(self.edge_coeffs[0])
+            print(type(self.edge_coeffs[0]))
             self.edge_coeffs.insert(0, self.edge_coeffs[0].restrict())  #_EdgeCoeffs(self.grids[n].grid, coeffs_c))
 
             # if we are periodic, then we should force the edge coefficents


### PR DESCRIPTION
This was to make the LM_atmosphere problem run under python3, which is the only problem I've checked (aside from running the basic advection and incompressible tests).
