### PR TITLE
Doc tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ inputs.auto
 .cache
 
 .pytest_cache/
+
+__pycache__/

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -63,6 +63,7 @@ Kelvin-Helmholtz problem ``kh``, we would do the following:
 
 .. code-block:: python
 
+    from pyro import Pyro
     pyro = Pyro("compressible")
     pyro.initialize_problem(problem_name="kh",
                             inputs_file="inputs.kh")


### PR DESCRIPTION
This adds a missing import to the python API example.

I've also added `__pycache__/` folders to gitignore so that folders that get created by numba don't pollute `git status`.