### PR TITLE
Doc fixes

### DIFF
--- a/docs/source/compressible_basics.rst
+++ b/docs/source/compressible_basics.rst
@@ -181,7 +181,7 @@ escape the domain. It is run as:
 
 .. code-block:: none
 
-   ./pyro.py compressible er inputs.rt
+   ./pyro.py compressible rt inputs.rt
 
 .. raw:: html
 

--- a/docs/source/multigrid_basics.rst
+++ b/docs/source/multigrid_basics.rst
@@ -32,11 +32,13 @@ Examples
 
 multigrid test
 ^^^^^^^^^^^^^^
-A basic multigrid test is run as:
+
+A basic multigrid test is run as (using a path relative to the root of the
+``pyro2`` repository):
 
 .. code-block:: none
 
-   ./mg_test_simple.py
+   ./examples/multigrid/mg_test_simple.py
 
 The ``mg_test_simple.py`` script solves a Poisson equation with a
 known analytic solution. This particular example comes from the text
@@ -77,17 +79,21 @@ The movie below shows the smoothing at each level to realize this solution:
         <iframe src="https://www.youtube.com/embed/h9MUgwJvr-g?rel=0" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
     </div><br>
 
+You can run this example locally by running the ``mg_vis.py`` script:
+
+.. code-block:: none
+
+   ./examples/multigrid/mg_vis.py
 
 projection
 ^^^^^^^^^^
 
-Another example (``examples/multigrid/project_periodic.py``) uses
-multigrid to extract the divergence free part of a velocity field.
-This is run as:
+Another example uses multigrid to extract the divergence free part of a velocity
+field.  This is run as:
 
 .. code-block:: none
 
-   ./project-periodic.py
+   ./examples/multigrid/project_periodic.py
 
 Given a vector field, :math:`U`, we can decompose it into a divergence free part, :math:`U_d`, and the gradient of a scalar, :math:`\phi`:
 

--- a/examples/multigrid/mg_test_simple.py
+++ b/examples/multigrid/mg_test_simple.py
@@ -84,6 +84,8 @@ def test_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.xlabel("x")
         plt.ylabel("y")
 
+        print("Saving figure to mg_test.png")
+
         plt.savefig("mg_test.png")
 
     # store the output for later comparison
@@ -114,4 +116,4 @@ def test_poisson_dirichlet(N, store_bench=False, comp_bench=False,
 
 
 if __name__ == "__main__":
-    test_poisson_dirichlet(256, comp_bench=True)
+    test_poisson_dirichlet(256, comp_bench=True, make_plot=True)


### PR DESCRIPTION
This fixes a typo in the compressible solver docs and makes it a bit clearer where the multigrid examples live, how to run them, and how to view a visualization from the simple multigrid test that the docs suggest to run.