### PR TITLE
Bug fix - error when hovering pop up window

### DIFF
--- a/advection/simulation.py
+++ b/advection/simulation.py
@@ -1,5 +1,6 @@
 import importlib
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 import advection.advective_fluxes as flx
@@ -118,6 +119,7 @@ class Simulation(NullSimulation):
 
         # needed for PDF rendering
         cb = axes.cbar_axes[0].colorbar(img)
+        cb.formatter = matplotlib.ticker.FormatStrFormatter("")
         cb.solids.set_rasterized(True)
         cb.solids.set_edgecolor("face")
 

--- a/advection_nonuniform/simulation.py
+++ b/advection_nonuniform/simulation.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import importlib
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 import advection_nonuniform.advective_fluxes as flx
@@ -145,6 +146,7 @@ class Simulation(NullSimulation):
 
         # needed for PDF rendering
         cb = axes.cbar_axes[0].colorbar(img)
+        cb.formatter = matplotlib.ticker.FormatStrFormatter("")
         cb.solids.set_rasterized(True)
         cb.solids.set_edgecolor("face")
 

--- a/analysis/plotvar.py
+++ b/analysis/plotvar.py
@@ -30,12 +30,12 @@ def makeplot(plotfile, variable, outfile,
     if log:
         var = np.log10(var)
 
-    plt.imshow(np.transpose(var.v()),
+    img = plt.imshow(np.transpose(var.v()),
                interpolation="nearest", origin="lower",
                extent=[myg.xmin, myg.xmax, myg.ymin, myg.ymax])
 
     if not compact:
-        plt.colorbar()
+        plt.colorbar(img)
 
         plt.xlabel("x")
         plt.ylabel("y")

--- a/compressible/simulation.py
+++ b/compressible/simulation.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import importlib
 
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 import compressible.BC as BC
@@ -281,6 +282,7 @@ class Simulation(NullSimulation):
 
             # needed for PDF rendering
             cb = axes.cbar_axes[n].colorbar(img)
+            cb.formatter = matplotlib.ticker.FormatStrFormatter("")
             cb.solids.set_rasterized(True)
             cb.solids.set_edgecolor("face")
 

--- a/compressible_react/simulation.py
+++ b/compressible_react/simulation.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -111,6 +112,7 @@ class Simulation(compressible.Simulation):
 
             # needed for PDF rendering
             cb = axes.cbar_axes[n].colorbar(img)
+            cb.formatter = matplotlib.ticker.FormatStrFormatter("")
             cb.solids.set_rasterized(True)
             cb.solids.set_edgecolor("face")
 

--- a/diffusion/simulation.py
+++ b/diffusion/simulation.py
@@ -3,6 +3,7 @@
 import importlib
 import math
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 import mesh.patch as patch
@@ -135,7 +136,7 @@ class Simulation(NullSimulation):
 
         myg = self.cc_data.grid
 
-        plt.imshow(np.transpose(phi.v()),
+        img = plt.imshow(np.transpose(phi.v()),
                    interpolation="nearest", origin="lower",
                    extent=[myg.xmin, myg.xmax, myg.ymin, myg.ymax],
                    cmap=self.cm)
@@ -144,7 +145,8 @@ class Simulation(NullSimulation):
         plt.ylabel("y")
         plt.title("phi")
 
-        plt.colorbar()
+        cb = plt.colorbar(img)
+        cb.formatter = matplotlib.ticker.FormatStrFormatter("")
 
         plt.figtext(0.05, 0.0125, "t = {:10.5f}".format(self.cc_data.t))
 

--- a/examples/multigrid/mg_test_general_alphabeta_only.py
+++ b/examples/multigrid/mg_test_general_alphabeta_only.py
@@ -145,7 +145,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
 
         plt.subplot(121)
 
-        plt.imshow(np.transpose(v.v()),
+        img1 = plt.imshow(np.transpose(v.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -153,11 +153,11 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("nx = {}".format(nx))
 
-        plt.colorbar()
+        plt.colorbar(img1)
 
         plt.subplot(122)
 
-        plt.imshow(np.transpose(e.v()),
+        img2 = plt.imshow(np.transpose(e.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -165,7 +165,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("error")
 
-        plt.colorbar()
+        plt.colorbar(img2)
 
         plt.tight_layout()
 

--- a/examples/multigrid/mg_test_general_beta_only.py
+++ b/examples/multigrid/mg_test_general_beta_only.py
@@ -145,7 +145,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
 
         plt.subplot(121)
 
-        plt.imshow(np.transpose(v.v()),
+        img1 = plt.imshow(np.transpose(v.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -153,11 +153,11 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("nx = {}".format(nx))
 
-        plt.colorbar()
+        plt.colorbar(img1)
 
         plt.subplot(122)
 
-        plt.imshow(np.transpose(e.v()),
+        img2 = plt.imshow(np.transpose(e.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -165,7 +165,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("error")
 
-        plt.colorbar()
+        plt.colorbar(img2)
 
         plt.tight_layout()
 

--- a/examples/multigrid/mg_test_general_constant.py
+++ b/examples/multigrid/mg_test_general_constant.py
@@ -131,7 +131,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
 
         plt.subplot(121)
 
-        plt.imshow(np.transpose(v.v()),
+        img1 = plt.imshow(np.transpose(v.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -139,11 +139,11 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("nx = {}".format(nx))
 
-        plt.colorbar()
+        plt.colorbar(img1)
 
         plt.subplot(122)
 
-        plt.imshow(np.transpose(e.v()),
+        img2 = plt.imshow(np.transpose(e.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -151,7 +151,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("error")
 
-        plt.colorbar()
+        plt.colorbar(img2)
 
         plt.tight_layout()
 

--- a/examples/multigrid/mg_test_general_dirichlet.py
+++ b/examples/multigrid/mg_test_general_dirichlet.py
@@ -150,7 +150,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
 
         plt.subplot(121)
 
-        plt.imshow(np.transpose(v.v()),
+        img1 = plt.imshow(np.transpose(v.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -158,11 +158,11 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("nx = {}".format(nx))
 
-        plt.colorbar()
+        plt.colorbar(img1)
 
         plt.subplot(122)
 
-        plt.imshow(np.transpose(e.v()),
+        img2 = plt.imshow(np.transpose(e.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -170,7 +170,7 @@ def test_general_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("error")
 
-        plt.colorbar()
+        plt.colorbar(img2)
 
         plt.tight_layout()
 

--- a/examples/multigrid/mg_test_general_inhomogeneous.py
+++ b/examples/multigrid/mg_test_general_inhomogeneous.py
@@ -168,7 +168,7 @@ def test_general_poisson_inhomogeneous(N, store_bench=False, comp_bench=False,
 
         plt.subplot(121)
 
-        plt.imshow(np.transpose(v.v()),
+        img1 = plt.imshow(np.transpose(v.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -176,11 +176,11 @@ def test_general_poisson_inhomogeneous(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("nx = {}".format(nx))
 
-        plt.colorbar()
+        plt.colorbar(img1)
 
         plt.subplot(122)
 
-        plt.imshow(np.transpose(e.v()),
+        img2 = plt.imshow(np.transpose(e.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -188,7 +188,7 @@ def test_general_poisson_inhomogeneous(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("error")
 
-        plt.colorbar()
+        plt.colorbar(img2)
 
         plt.tight_layout()
 

--- a/examples/multigrid/mg_test_vc_constant.py
+++ b/examples/multigrid/mg_test_vc_constant.py
@@ -64,7 +64,7 @@ def test_vc_constant(N):
 
     plt.figure(num=1, figsize=(5.0, 5.0), dpi=100, facecolor='w')
 
-    plt.imshow(np.transpose(c[g.ilo:g.ihi+1, g.jlo:g.jhi+1]),
+    img1 = plt.imshow(np.transpose(c[g.ilo:g.ihi+1, g.jlo:g.jhi+1]),
                interpolation="nearest", origin="lower",
                extent=[g.xmin, g.xmax, g.ymin, g.ymax])
 
@@ -72,7 +72,7 @@ def test_vc_constant(N):
     plt.ylabel("y")
     plt.title("nx = {}".format(nx))
 
-    plt.colorbar()
+    plt.colorbar(img1)
 
     plt.savefig("mg_alpha.png")
 
@@ -117,7 +117,7 @@ def test_vc_constant(N):
 
     plt.subplot(121)
 
-    plt.imshow(np.transpose(v[a.ilo:a.ihi+1, a.jlo:a.jhi+1]),
+    img2 = plt.imshow(np.transpose(v[a.ilo:a.ihi+1, a.jlo:a.jhi+1]),
                interpolation="nearest", origin="lower",
                extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -125,11 +125,11 @@ def test_vc_constant(N):
     plt.ylabel("y")
     plt.title("nx = {}".format(nx))
 
-    plt.colorbar()
+    plt.colorbar(img2)
 
     plt.subplot(122)
 
-    plt.imshow(np.transpose(e[a.ilo:a.ihi+1, a.jlo:a.jhi+1]),
+    img3 = plt.imshow(np.transpose(e[a.ilo:a.ihi+1, a.jlo:a.jhi+1]),
                interpolation="nearest", origin="lower",
                extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -137,7 +137,7 @@ def test_vc_constant(N):
     plt.ylabel("y")
     plt.title("error")
 
-    plt.colorbar()
+    plt.colorbar(img3)
 
     plt.tight_layout()
 

--- a/examples/multigrid/mg_test_vc_dirichlet.py
+++ b/examples/multigrid/mg_test_vc_dirichlet.py
@@ -119,7 +119,7 @@ def test_vc_poisson_dirichlet(N, store_bench=False, comp_bench=False,
 
         plt.subplot(121)
 
-        plt.imshow(np.transpose(v.v()),
+        img1 = plt.imshow(np.transpose(v.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -127,11 +127,11 @@ def test_vc_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("nx = {}".format(nx))
 
-        plt.colorbar()
+        plt.colorbar(img1)
 
         plt.subplot(122)
 
-        plt.imshow(np.transpose(e.v()),
+        img2 = plt.imshow(np.transpose(e.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -139,7 +139,7 @@ def test_vc_poisson_dirichlet(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("error")
 
-        plt.colorbar()
+        plt.colorbar(img2)
 
         plt.tight_layout()
 

--- a/examples/multigrid/mg_test_vc_periodic.py
+++ b/examples/multigrid/mg_test_vc_periodic.py
@@ -129,7 +129,7 @@ def test_vc_poisson_periodic(N, store_bench=False, comp_bench=False,
 
         plt.subplot(121)
 
-        plt.imshow(np.transpose(v.v()),
+        img1 = plt.imshow(np.transpose(v.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -137,11 +137,11 @@ def test_vc_poisson_periodic(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("nx = {}".format(nx))
 
-        plt.colorbar()
+        plt.colorbar(img1)
 
         plt.subplot(122)
 
-        plt.imshow(np.transpose(e.v()),
+        img2 = plt.imshow(np.transpose(e.v()),
                    interpolation="nearest", origin="lower",
                    extent=[a.xmin, a.xmax, a.ymin, a.ymax])
 
@@ -149,7 +149,7 @@ def test_vc_poisson_periodic(N, store_bench=False, comp_bench=False,
         plt.ylabel("y")
         plt.title("error")
 
-        plt.colorbar()
+        plt.colorbar(img2)
 
         plt.tight_layout()
 

--- a/swe/simulation.py
+++ b/swe/simulation.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import importlib
 
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 import swe.derives as derives
@@ -263,6 +264,7 @@ class Simulation(NullSimulation):
 
             # needed for PDF rendering
             cb = axes.cbar_axes[n].colorbar(img)
+            cb.formatter = matplotlib.ticker.FormatStrFormatter("")
             cb.solids.set_rasterized(True)
             cb.solids.set_edgecolor("face")
 


### PR DESCRIPTION
Hi there,

This is in reference to #84. 

For one, `cb.formatter = matplotlib.ticker.FormatStrFormatter("")` prevents a bug in matplotlib where it expects a formatter attribute. The current format does not break the animation but you will see it if you click a chart while it is running and look in your terminal. It adds x and y axis data related to the chart as well as an []. The empty array has data by default that is quite meaningless so `FormatStrFormatter("")` gets rid of the data inside.

My first instinct to fix this was this: `img = plt.imshow(np.transpose(var.v()),` and `plt.colorbar(img)` because of [this stack overflow page](https://stackoverflow.com/questions/2643953/attributeerror-while-adding-colorbar-in-matplotlib). I kept this change in code as it looks to be a best practice (though I am not sure the exact benefit). 

Otherwise, let me know if it works.

Jerry