### PR TITLE
the legacy_colorbar matplotlib option doesn't exist in mpl 3.1 or earlier

### DIFF
--- a/advection/simulation.py
+++ b/advection/simulation.py
@@ -1,7 +1,10 @@
 import importlib
 import numpy as np
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 
 import advection.advective_fluxes as flx

--- a/advection_nonuniform/simulation.py
+++ b/advection_nonuniform/simulation.py
@@ -3,7 +3,10 @@ from __future__ import print_function
 import importlib
 import numpy as np
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 
 import advection_nonuniform.advective_fluxes as flx

--- a/compressible/simulation.py
+++ b/compressible/simulation.py
@@ -4,7 +4,10 @@ import importlib
 
 import numpy as np
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 
 import compressible.BC as BC

--- a/compressible_react/simulation.py
+++ b/compressible_react/simulation.py
@@ -1,7 +1,10 @@
 from __future__ import print_function
 
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/compressible_sr/simulation.py
+++ b/compressible_sr/simulation.py
@@ -2,7 +2,10 @@ from __future__ import print_function
 
 import importlib
 import matplotlib 
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/diffusion/simulation.py
+++ b/diffusion/simulation.py
@@ -4,7 +4,10 @@ import importlib
 import math
 import numpy as np
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 
 import mesh.patch as patch

--- a/incompressible/simulation.py
+++ b/incompressible/simulation.py
@@ -4,7 +4,10 @@ import importlib
 
 import numpy as np
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 
 import incompressible.incomp_interface as incomp_interface

--- a/lm_atm/simulation.py
+++ b/lm_atm/simulation.py
@@ -4,7 +4,10 @@ import importlib
 
 import numpy as np
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 
 import lm_atm.LM_atm_interface as lm_interface

--- a/swe/simulation.py
+++ b/swe/simulation.py
@@ -4,7 +4,10 @@ import importlib
 
 import numpy as np
 import matplotlib
-matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+try:
+    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
+except KeyError:
+    pass
 import matplotlib.pyplot as plt
 
 import swe.derives as derives


### PR DESCRIPTION
…lier