### PR TITLE
Allow running pyro_sim.py from anywhere

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -44,7 +44,5 @@ jobs:
         run: python setup.py install --user
 
       - name: Run tests via test.py
-        run: |
-          cd pyro
-          ./test.py
+        run: ./pyro/test.py
 

--- a/pyro/pyro_sim.py
+++ b/pyro/pyro_sim.py
@@ -296,8 +296,8 @@ class PyroBenchmark(Pyro):
         """ Are we comparing to a benchmark? """
 
         basename = self.rp.get_param("io.basename")
-        compare_file = "{}/tests/{}{:04d}".format(
-            self.solver_name, basename, self.sim.n)
+        compare_file = "{}{}/tests/{}{:04d}".format(
+            self.pyro_home, self.solver_name, basename, self.sim.n)
         msg.warning(f"comparing to: {compare_file} ")
         try:
             sim_bench = io.read(compare_file)
@@ -317,9 +317,9 @@ class PyroBenchmark(Pyro):
     def store_as_benchmark(self):
         """ Are we storing a benchmark? """
 
-        if not os.path.isdir(self.solver_name + "/tests/"):
+        if not os.path.isdir(self.pyro_home + self.solver_name + "/tests/"):
             try:
-                os.mkdir(self.solver_name + "/tests/")
+                os.mkdir(self.pyro_home + self.solver_name + "/tests/")
             except (FileNotFoundError, PermissionError):
                 msg.fail(
                     "ERROR: unable to create the solver's tests/ directory")
@@ -357,7 +357,7 @@ def parse_args():
     return p.parse_args()
 
 
-if __name__ == "__main__":
+def main():
     args = parse_args()
 
     if args.compare_benchmark or args.make_benchmark:
@@ -371,3 +371,7 @@ if __name__ == "__main__":
                             inputs_file=args.param[0],
                             other_commands=args.other)
     pyro.run_sim()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyro/test.py
+++ b/pyro/test.py
@@ -10,6 +10,7 @@ import examples.multigrid.mg_test_general_inhomogeneous as mg_test_general_inhom
 import examples.multigrid.mg_test_simple as mg_test_simple
 import examples.multigrid.mg_test_vc_dirichlet as mg_test_vc_dirichlet
 import examples.multigrid.mg_test_vc_periodic as mg_test_vc_periodic
+
 import pyro.pyro_sim as pyro
 
 
@@ -70,23 +71,24 @@ def do_tests(out_file,
 
     # standalone tests
     if single is None:
-        err = mg_test_simple.test_poisson_dirichlet(256, comp_bench=True, bench_dir="multigrid/tests/",
+        bench_dir = os.path.dirname(os.path.realpath(__file__)) + "/multigrid/tests/"
+        err = mg_test_simple.test_poisson_dirichlet(256, comp_bench=True, bench_dir=bench_dir,
                                                     store_bench=store_all_benchmarks, verbose=0)
         results["mg_poisson_dirichlet"] = err
 
         err = mg_test_vc_dirichlet.test_vc_poisson_dirichlet(512,
-                                                             comp_bench=True, bench_dir="multigrid/tests/",
+                                                             comp_bench=True, bench_dir=bench_dir,
                                                              store_bench=store_all_benchmarks, verbose=0)
         results["mg_vc_poisson_dirichlet"] = err
 
-        err = mg_test_vc_periodic.test_vc_poisson_periodic(512, comp_bench=True, bench_dir="multigrid/tests/",
+        err = mg_test_vc_periodic.test_vc_poisson_periodic(512, comp_bench=True, bench_dir=bench_dir,
                                                            store_bench=store_all_benchmarks,
                                                            verbose=0)
         results["mg_vc_poisson_periodic"] = err
 
         err = mg_test_general_inhomogeneous.test_general_poisson_inhomogeneous(512,
                                                                                comp_bench=True,
-                                                                               bench_dir="multigrid/tests/",
+                                                                               bench_dir=bench_dir,
                                                                                store_bench=store_all_benchmarks,
                                                                                verbose=0)
         results["mg_general_poisson_inhomogeneous"] = err

--- a/pyro/test.py
+++ b/pyro/test.py
@@ -10,7 +10,6 @@ import examples.multigrid.mg_test_general_inhomogeneous as mg_test_general_inhom
 import examples.multigrid.mg_test_simple as mg_test_simple
 import examples.multigrid.mg_test_vc_dirichlet as mg_test_vc_dirichlet
 import examples.multigrid.mg_test_vc_periodic as mg_test_vc_periodic
-
 import pyro.pyro_sim as pyro
 
 

--- a/pyro/util/runparams.py
+++ b/pyro/util/runparams.py
@@ -47,6 +47,7 @@ read default values.
 import os
 import re
 import textwrap
+from pathlib import Path
 
 from pyro.util import msg
 
@@ -118,7 +119,7 @@ class RuntimeParameters:
 
         # check to see whether the file exists
         if not os.path.isfile(pfile):
-            pfile = "{}/{}".format(os.environ["PYRO_HOME"], pfile)
+            pfile = str(Path(__file__).resolve().parents[1] / pfile)
 
         try:
             f = open(pfile)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 import glob
+from pathlib import Path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # find all of the "_default" files
 defaults = []
@@ -40,7 +40,11 @@ setup(name='pyro',
       url='https://github.com/python-hydro/pyro2',
       license='BSD',
       packages=find_packages(),
-      scripts=["pyro/pyro_sim.py"],
+      entry_points={
+          "console_scripts": [
+              "pyro_sim.py = pyro.pyro_sim:main",
+          ]
+      },
       package_data={"pyro": benchmarks + defaults + inputs},
       install_requires=['numpy', 'numba', 'matplotlib', 'h5py'],
       use_scm_version={"version_scheme": "post-release",


### PR DESCRIPTION
I changed setup.py to install an autogenerated shim script that loads pyro.pyro_sim as a module, as otherwise `__file__` would point to the bin directory it gets installed to, rather than the pyro/ directory.

With a minor change to test.py, this lets us run the regression tests from outside pyro/ as well.