### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/pyro/advection/simulation.py
+++ b/pyro/advection/simulation.py
@@ -1,13 +1,8 @@
 import importlib
 
 import matplotlib
-import numpy as np
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
+import numpy as np
 
 import pyro.advection.advective_fluxes as flx
 import pyro.mesh.patch as patch

--- a/pyro/advection_nonuniform/simulation.py
+++ b/pyro/advection_nonuniform/simulation.py
@@ -1,13 +1,8 @@
 import importlib
 
 import matplotlib
-import numpy as np
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
+import numpy as np
 
 import pyro.advection_nonuniform.advective_fluxes as flx
 import pyro.mesh.patch as patch

--- a/pyro/compressible/simulation.py
+++ b/pyro/compressible/simulation.py
@@ -1,13 +1,8 @@
 import importlib
 
 import matplotlib
-import numpy as np
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
+import numpy as np
 
 import pyro.compressible.BC as BC
 import pyro.compressible.derives as derives

--- a/pyro/compressible_react/simulation.py
+++ b/pyro/compressible_react/simulation.py
@@ -1,9 +1,4 @@
 import matplotlib
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/pyro/compressible_sr/simulation.py
+++ b/pyro/compressible_sr/simulation.py
@@ -1,11 +1,5 @@
 import importlib
 
-import matplotlib
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/pyro/diffusion/simulation.py
+++ b/pyro/diffusion/simulation.py
@@ -4,13 +4,8 @@ import importlib
 import math
 
 import matplotlib
-import numpy as np
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
+import numpy as np
 
 import pyro.mesh.patch as patch
 import pyro.multigrid.MG as MG

--- a/pyro/incompressible/simulation.py
+++ b/pyro/incompressible/simulation.py
@@ -1,13 +1,7 @@
 import importlib
 
-import matplotlib
-import numpy as np
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
+import numpy as np
 
 import pyro.incompressible.incomp_interface as incomp_interface
 import pyro.mesh.array_indexer as ai

--- a/pyro/lm_atm/simulation.py
+++ b/pyro/lm_atm/simulation.py
@@ -1,13 +1,7 @@
 import importlib
 
-import matplotlib
-import numpy as np
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
+import numpy as np
 
 import pyro.lm_atm.LM_atm_interface as lm_interface
 import pyro.mesh.array_indexer as ai

--- a/pyro/mesh/tests/test_patch.py
+++ b/pyro/mesh/tests/test_patch.py
@@ -87,7 +87,7 @@ class TestCellCenterData2d(object):
         nx = 8
         ny = 8
         self.g = patch.Grid2d(nx, ny, ng=2, xmax=1.0, ymax=1.0)
-        self.d = patch.CellCenterData2d(self.g, dtype=np.int)
+        self.d = patch.CellCenterData2d(self.g, dtype=int)
 
         bco = bnd.BC(xlb="outflow", xrb="outflow",
                      ylb="outflow", yrb="outflow")
@@ -158,7 +158,7 @@ class TestCellCenterData2d(object):
 def test_bcs():
 
     myg = patch.Grid2d(4, 4, ng=2, xmax=1.0, ymax=1.0)
-    myd = patch.CellCenterData2d(myg, dtype=np.int)
+    myd = patch.CellCenterData2d(myg, dtype=int)
 
     bco = bnd.BC(xlb="outflow", xrb="outflow",
                  ylb="outflow", yrb="outflow")

--- a/pyro/swe/simulation.py
+++ b/pyro/swe/simulation.py
@@ -1,13 +1,8 @@
 import importlib
 
 import matplotlib
-import numpy as np
-
-try:
-    matplotlib.rcParams['mpl_toolkits.legacy_colorbar'] = False
-except KeyError:
-    pass
 import matplotlib.pyplot as plt
+import numpy as np
 
 import pyro.mesh.boundary as bnd
 import pyro.particles.particles as particles


### PR DESCRIPTION
`mpl_toolkits.legacy_colorbar = False` is a no-op as of matplotlib 3.4