### PR TITLE
Pylint style fixes, pass 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,15 @@ enable = [
   "use-symbolic-message-instead",
 ]
 
+[tool.pylint.CLASSES]
+defining-attr-methods = [
+  "__init__",
+  "__new__",
+  "setUp",
+  "__post_init__",
+  "initialize",
+  "__array_finalize__",
+]
+
 [tool.pylint.FORMAT]
 max-line-length = 132

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ disable = [
   "missing-function-docstring",
   "missing-module-docstring",
 ]
+enable = [
+  "useless-suppression",
+  "use-symbolic-message-instead",
+]
 
 [tool.pylint.FORMAT]
 max-line-length = 132

--- a/pyro/advection/advective_fluxes.py
+++ b/pyro/advection/advective_fluxes.py
@@ -1,4 +1,4 @@
-import pyro.mesh.reconstruction as reconstruction
+from pyro.mesh import reconstruction
 
 
 def unsplit_fluxes(my_data, rp, dt, scalar_name):

--- a/pyro/advection/problems/smooth.py
+++ b/pyro/advection/problems/smooth.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/advection/problems/smooth.py
+++ b/pyro/advection/problems/smooth.py
@@ -34,4 +34,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/advection/problems/test.py
+++ b/pyro/advection/problems/test.py
@@ -23,4 +23,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/advection/problems/test.py
+++ b/pyro/advection/problems/test.py
@@ -1,6 +1,6 @@
 import sys
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 
 
 def init_data(my_data, rp):

--- a/pyro/advection/problems/tophat.py
+++ b/pyro/advection/problems/tophat.py
@@ -1,6 +1,6 @@
 import sys
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/advection/problems/tophat.py
+++ b/pyro/advection/problems/tophat.py
@@ -37,4 +37,3 @@ def init_data(myd, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/advection/simulation.py
+++ b/pyro/advection/simulation.py
@@ -5,10 +5,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pyro.advection.advective_fluxes as flx
-import pyro.mesh.patch as patch
-import pyro.particles.particles as particles
-import pyro.util.plot_tools as plot_tools
+from pyro.mesh import patch
+from pyro.particles import particles
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
+from pyro.util import plot_tools
 
 
 class Simulation(NullSimulation):

--- a/pyro/advection_fv4/fluxes.py
+++ b/pyro/advection_fv4/fluxes.py
@@ -1,5 +1,5 @@
-import pyro.advection_fv4.interface as interface
 import pyro.mesh.array_indexer as ai
+from pyro.advection_fv4 import interface
 
 
 def fluxes(my_data, rp, dt):

--- a/pyro/advection_fv4/interface.py
+++ b/pyro/advection_fv4/interface.py
@@ -224,7 +224,7 @@ def states(a, ng, idir):
 
                 else:
                     # if Eqs. 24 or 25 didn't hold we still may need to limit
-                    if ():
+                    if abs(dafm[i, j]) >= 2.0 * abs(dafp[i, j]):
                         ar[i, j] = a[i, j] - 2.0 * dafp[i, j]
 
                     if abs(dafp[i, j]) >= 2.0 * abs(dafm[i, j]):

--- a/pyro/advection_fv4/interface.py
+++ b/pyro/advection_fv4/interface.py
@@ -52,7 +52,7 @@ def states(a, ng, idir):
     jhi = ng + ny
 
     # we need interface values on all faces of the domain
-    if (idir == 1):
+    if idir == 1:
 
         for i in range(ilo - 2, ihi + 3):
             for j in range(jlo - 1, jhi + 1):
@@ -110,14 +110,14 @@ def states(a, ng, idir):
                         # MC Eq. 27
                         rho = d2a_lim / d2af[i, j]
 
-                    if (rho < 1.0 - 1.e-12):
+                    if rho < 1.0 - 1.e-12:
                         # we may need to limit -- these quantities are at cell-centers
                         d3a_min = min(d3a[i - 1, j], d3a[i, j],
                                       d3a[i + 1, j], d3a[i + 2, j])
                         d3a_max = max(d3a[i - 1, j], d3a[i, j],
                                       d3a[i + 1, j], d3a[i + 2, j])
 
-                        if (C3 * max(abs(d3a_min), abs(d3a_max)) <= (d3a_max - d3a_min)):
+                        if C3 * max(abs(d3a_min), abs(d3a_max)) <= (d3a_max - d3a_min):
                             # limit
                             if (dafm[i, j] * dafp[i, j] < 0.0):
                                 # Eqs. 29, 30
@@ -135,13 +135,13 @@ def states(a, ng, idir):
 
                 else:
                     # if Eqs. 24 or 25 didn't hold we still may need to limit
-                    if (abs(dafm[i, j]) >= 2.0 * abs(dafp[i, j])):
+                    if abs(dafm[i, j]) >= 2.0 * abs(dafp[i, j]):
                         ar[i, j] = a[i, j] - 2.0 * dafp[i, j]
 
-                    if (abs(dafp[i, j]) >= 2.0 * abs(dafm[i, j])):
+                    if abs(dafp[i, j]) >= 2.0 * abs(dafm[i, j]):
                         al[i + 1, j] = a[i, j] + 2.0 * dafm[i, j]
 
-    elif (idir == 2):
+    elif idir == 2:
 
         for i in range(ilo - 1, ihi + 1):
             for j in range(jlo - 2, jhi + 3):
@@ -199,14 +199,14 @@ def states(a, ng, idir):
                         # MC Eq. 27
                         rho = d2a_lim / d2af[i, j]
 
-                    if (rho < 1.0 - 1.e-12):
+                    if rho < 1.0 - 1.e-12:
                         # we may need to limit -- these quantities are at cell-centers
                         d3a_min = min(d3a[i, j - 1], d3a[i, j],
                                       d3a[i, j + 1], d3a[i, j + 2])
                         d3a_max = max(d3a[i, j - 1], d3a[i, j],
                                       d3a[i, j + 1], d3a[i, j + 2])
 
-                        if (C3 * max(abs(d3a_min), abs(d3a_max)) <= (d3a_max - d3a_min)):
+                        if C3 * max(abs(d3a_min), abs(d3a_max)) <= (d3a_max - d3a_min):
                             # limit
                             if (dafm[i, j] * dafp[i, j] < 0.0):
                                 # Eqs. 29, 30
@@ -224,10 +224,10 @@ def states(a, ng, idir):
 
                 else:
                     # if Eqs. 24 or 25 didn't hold we still may need to limit
-                    if (abs(dafm[i, j]) >= 2.0 * abs(dafp[i, j])):
+                    if ():
                         ar[i, j] = a[i, j] - 2.0 * dafp[i, j]
 
-                    if (abs(dafp[i, j]) >= 2.0 * abs(dafm[i, j])):
+                    if abs(dafp[i, j]) >= 2.0 * abs(dafm[i, j]):
                         al[i, j + 1] = a[i, j] + 2.0 * dafm[i, j]
 
     return al, ar
@@ -273,7 +273,7 @@ def states_nolimit(a, qx, qy, ng, idir):
     jhi = ng + ny
 
     # we need interface values on all faces of the domain
-    if (idir == 1):
+    if idir == 1:
 
         for i in range(ilo - 2, ihi + 3):
             for j in range(jlo - 1, jhi + 1):
@@ -285,7 +285,7 @@ def states_nolimit(a, qx, qy, ng, idir):
                 al[i, j] = a_int[i, j]
                 ar[i, j] = a_int[i, j]
 
-    elif (idir == 2):
+    elif idir == 2:
 
         for i in range(ilo - 1, ihi + 1):
             for j in range(jlo - 2, jhi + 3):

--- a/pyro/advection_fv4/problems/smooth.py
+++ b/pyro/advection_fv4/problems/smooth.py
@@ -1,6 +1,6 @@
 import numpy
 
-import pyro.mesh.fv as fv
+from pyro.mesh import fv
 from pyro.util import msg
 
 

--- a/pyro/advection_fv4/problems/smooth.py
+++ b/pyro/advection_fv4/problems/smooth.py
@@ -45,4 +45,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/advection_fv4/simulation.py
+++ b/pyro/advection_fv4/simulation.py
@@ -1,10 +1,10 @@
 import importlib
 
 import pyro.advection_fv4.fluxes as flx
-import pyro.advection_rk as advection_rk
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.fv as fv
-import pyro.particles.particles as particles
+from pyro import advection_rk
+from pyro.mesh import fv
+from pyro.particles import particles
 from pyro.simulation_null import bc_setup, grid_setup
 
 

--- a/pyro/advection_nonuniform/advective_fluxes.py
+++ b/pyro/advection_nonuniform/advective_fluxes.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import pyro.mesh.reconstruction as reconstruction
+from pyro.mesh import reconstruction
 
 
 def unsplit_fluxes(my_data, rp, dt, scalar_name):

--- a/pyro/advection_nonuniform/problems/slotted.py
+++ b/pyro/advection_nonuniform/problems/slotted.py
@@ -51,4 +51,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/advection_nonuniform/problems/slotted.py
+++ b/pyro/advection_nonuniform/problems/slotted.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/advection_nonuniform/problems/test.py
+++ b/pyro/advection_nonuniform/problems/test.py
@@ -1,4 +1,4 @@
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/advection_nonuniform/problems/test.py
+++ b/pyro/advection_nonuniform/problems/test.py
@@ -27,4 +27,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/advection_nonuniform/simulation.py
+++ b/pyro/advection_nonuniform/simulation.py
@@ -5,10 +5,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pyro.advection_nonuniform.advective_fluxes as flx
-import pyro.mesh.patch as patch
-import pyro.particles.particles as particles
-import pyro.util.plot_tools as plot_tools
+from pyro.mesh import patch
+from pyro.particles import particles
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
+from pyro.util import plot_tools
 
 
 class Simulation(NullSimulation):

--- a/pyro/advection_rk/fluxes.py
+++ b/pyro/advection_rk/fluxes.py
@@ -1,4 +1,4 @@
-import pyro.mesh.reconstruction as reconstruction
+from pyro.mesh import reconstruction
 
 
 def fluxes(my_data, rp, dt):

--- a/pyro/advection_rk/simulation.py
+++ b/pyro/advection_rk/simulation.py
@@ -1,7 +1,7 @@
-import pyro.advection as advection
 import pyro.advection_rk.fluxes as flx
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.integration as integration
+from pyro import advection
+from pyro.mesh import integration
 
 
 class Simulation(advection.Simulation):

--- a/pyro/advection_weno/fluxes.py
+++ b/pyro/advection_weno/fluxes.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import pyro.mesh.reconstruction as reconstruction
+from pyro.mesh import reconstruction
 
 
 def fvs(q, order, u, alpha):

--- a/pyro/advection_weno/simulation.py
+++ b/pyro/advection_weno/simulation.py
@@ -1,7 +1,7 @@
-import pyro.advection as advection
 import pyro.advection_weno.fluxes as flx
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.integration as integration
+from pyro import advection
+from pyro.mesh import integration
 
 
 class Simulation(advection.Simulation):

--- a/pyro/analysis/dam_compare.py
+++ b/pyro/analysis/dam_compare.py
@@ -171,7 +171,7 @@ ax.scatter(x, u, marker="x", s=7, color="r")
 ax.set_ylabel(r"$u$")
 ax.set_xlim(0, 1.0)
 
-if (myg.nx > myg.ny):
+if myg.nx > myg.ny:
     ax.set_xlabel(r"x")
 else:
     ax.set_xlabel(r"y")

--- a/pyro/analysis/gauss_diffusion_compare.py
+++ b/pyro/analysis/gauss_diffusion_compare.py
@@ -7,8 +7,8 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.diffusion.problems.gaussian as gaussian
 import pyro.util.io_pyro as io
+from pyro.diffusion.problems import gaussian
 
 mpl.rcParams["text.usetex"] = True
 mpl.rcParams['mathtext.fontset'] = 'cm'

--- a/pyro/analysis/plotvar.py
+++ b/pyro/analysis/plotvar.py
@@ -5,8 +5,8 @@ import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.mesh.patch as patch
 import pyro.util.io_pyro as io
+from pyro.mesh import patch
 
 # plot a single variable from an output file
 #

--- a/pyro/analysis/smooth_error.py
+++ b/pyro/analysis/smooth_error.py
@@ -6,8 +6,8 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
 import pyro.util.io_pyro as io
+from pyro.mesh import patch
 
 usage = """
       compare the output in file from the smooth advection problem to

--- a/pyro/analysis/sod_compare.py
+++ b/pyro/analysis/sod_compare.py
@@ -121,7 +121,7 @@ ax = axes.flat[3]
 ax.plot(x_exact, e_exact)
 ax.scatter(x, e, marker="x", s=7, color="r")
 
-if (myg.nx > myg.ny):
+if myg.nx > myg.ny:
     ax.set_xlabel(r"x")
 else:
     ax.set_xlabel(r"y")

--- a/pyro/compressible/problems/acoustic_pulse.py
+++ b/pyro/compressible/problems/acoustic_pulse.py
@@ -57,4 +57,3 @@ def init_data(myd, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/acoustic_pulse.py
+++ b/pyro/compressible/problems/acoustic_pulse.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.fv as fv
+from pyro.mesh import fv
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/advect.py
+++ b/pyro/compressible/problems/advect.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/bubble.py
+++ b/pyro/compressible/problems/bubble.py
@@ -79,4 +79,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/bubble.py
+++ b/pyro/compressible/problems/bubble.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/gresho.py
+++ b/pyro/compressible/problems/gresho.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/gresho.py
+++ b/pyro/compressible/problems/gresho.py
@@ -78,4 +78,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the userad at the end of the run """
-    pass

--- a/pyro/compressible/problems/hse.py
+++ b/pyro/compressible/problems/hse.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/hse.py
+++ b/pyro/compressible/problems/hse.py
@@ -60,4 +60,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/kh.py
+++ b/pyro/compressible/problems/kh.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/kh.py
+++ b/pyro/compressible/problems/kh.py
@@ -74,4 +74,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/logo.py
+++ b/pyro/compressible/problems/logo.py
@@ -3,7 +3,7 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/quad.py
+++ b/pyro/compressible/problems/quad.py
@@ -91,4 +91,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/quad.py
+++ b/pyro/compressible/problems/quad.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/ramp.py
+++ b/pyro/compressible/problems/ramp.py
@@ -83,4 +83,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/ramp.py
+++ b/pyro/compressible/problems/ramp.py
@@ -3,7 +3,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/rt.py
+++ b/pyro/compressible/problems/rt.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/rt.py
+++ b/pyro/compressible/problems/rt.py
@@ -70,4 +70,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/rt.py
+++ b/pyro/compressible/problems/rt.py
@@ -49,7 +49,7 @@ def init_data(my_data, rp):
 
     j = myg.jlo
     while j <= myg.jhi:
-        if (myg.y[j] < ycenter):
+        if myg.y[j] < ycenter:
             dens[:, j] = dens1
             p[:, j] = p0 + dens1*grav*myg.y[j]
 

--- a/pyro/compressible/problems/rt2.py
+++ b/pyro/compressible/problems/rt2.py
@@ -86,4 +86,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/rt2.py
+++ b/pyro/compressible/problems/rt2.py
@@ -59,7 +59,7 @@ def init_data(my_data, rp):
 
     j = myg.jlo
     while j <= myg.jhi:
-        if (myg.y[j] < ycenter):
+        if myg.y[j] < ycenter:
             dens[:, j] = dens1
             p[:, j] = p0 + dens1*grav*myg.y[j]
 

--- a/pyro/compressible/problems/rt2.py
+++ b/pyro/compressible/problems/rt2.py
@@ -8,7 +8,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/sedov.py
+++ b/pyro/compressible/problems/sedov.py
@@ -3,7 +3,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/sod.py
+++ b/pyro/compressible/problems/sod.py
@@ -1,6 +1,6 @@
 import sys
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible/problems/test.py
+++ b/pyro/compressible/problems/test.py
@@ -29,4 +29,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible/problems/test.py
+++ b/pyro/compressible/problems/test.py
@@ -1,6 +1,6 @@
 import sys
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 
 
 def init_data(my_data, rp):

--- a/pyro/compressible/simulation.py
+++ b/pyro/compressible/simulation.py
@@ -4,14 +4,12 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.compressible.BC as BC
-import pyro.compressible.derives as derives
-import pyro.compressible.eos as eos
 import pyro.compressible.unsplit_fluxes as flx
 import pyro.mesh.boundary as bnd
-import pyro.particles.particles as particles
-import pyro.util.plot_tools as plot_tools
+from pyro.compressible import BC, derives, eos
+from pyro.particles import particles
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
+from pyro.util import plot_tools
 
 
 class Variables:

--- a/pyro/compressible/unsplit_fluxes.py
+++ b/pyro/compressible/unsplit_fluxes.py
@@ -125,7 +125,7 @@ Updating U_{i,j}:
 import pyro.compressible as comp
 import pyro.compressible.interface as ifc
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.reconstruction as reconstruction
+from pyro.mesh import reconstruction
 from pyro.util import msg
 
 

--- a/pyro/compressible_fv4/fluxes.py
+++ b/pyro/compressible_fv4/fluxes.py
@@ -2,11 +2,11 @@
 
 import numpy as np
 
-import pyro.advection_fv4.interface as interface
 import pyro.compressible as comp
 import pyro.compressible.interface as cf
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.reconstruction as reconstruction
+from pyro.advection_fv4 import interface
+from pyro.mesh import reconstruction
 
 
 def flux_cons(ivars, idir, gamma, q):

--- a/pyro/compressible_fv4/simulation.py
+++ b/pyro/compressible_fv4/simulation.py
@@ -1,7 +1,6 @@
 import pyro.compressible_fv4.fluxes as flx
-import pyro.compressible_rk as compressible_rk
-import pyro.mesh.fv as fv
-import pyro.mesh.integration as integration
+from pyro import compressible_rk
+from pyro.mesh import fv, integration
 
 
 class Simulation(compressible_rk.Simulation):

--- a/pyro/compressible_react/problems/flame.py
+++ b/pyro/compressible_react/problems/flame.py
@@ -3,7 +3,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_react/problems/rt.py
+++ b/pyro/compressible_react/problems/rt.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_react/problems/rt.py
+++ b/pyro/compressible_react/problems/rt.py
@@ -56,7 +56,7 @@ def init_data(my_data, rp):
 
     j = myg.jlo
     while j <= myg.jhi:
-        if (myg.y[j] < ycenter):
+        if myg.y[j] < ycenter:
             dens[:, j] = dens1
             p[:, j] = p0 + dens1*grav*myg.y[j]
             ash[:, j] = dens1

--- a/pyro/compressible_react/problems/rt.py
+++ b/pyro/compressible_react/problems/rt.py
@@ -78,4 +78,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_react/simulation.py
+++ b/pyro/compressible_react/simulation.py
@@ -24,7 +24,6 @@ class Simulation(compressible.Simulation):
         # compute energy generation rate
 
         # update energy due to reaction
-        pass
 
     def diffuse(self, dt):
         """ diffuse for dt """
@@ -34,7 +33,6 @@ class Simulation(compressible.Simulation):
         # compute div kappa grad T
 
         # update energy due to diffusion
-        pass
 
     def evolve(self):
         """

--- a/pyro/compressible_react/simulation.py
+++ b/pyro/compressible_react/simulation.py
@@ -2,9 +2,9 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.compressible as compressible
-import pyro.compressible.eos as eos
-import pyro.util.plot_tools as plot_tools
+from pyro import compressible
+from pyro.compressible import eos
+from pyro.util import plot_tools
 
 
 class Simulation(compressible.Simulation):

--- a/pyro/compressible_rk/fluxes.py
+++ b/pyro/compressible_rk/fluxes.py
@@ -20,9 +20,9 @@ Taylor expanding *in space only* yields::
 """
 
 import pyro.compressible as comp
-import pyro.compressible.interface as interface
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.reconstruction as reconstruction
+from pyro.compressible import interface
+from pyro.mesh import reconstruction
 from pyro.util import msg
 
 

--- a/pyro/compressible_rk/simulation.py
+++ b/pyro/compressible_rk/simulation.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-import pyro.compressible as compressible
 import pyro.compressible_rk.fluxes as flx
-import pyro.mesh.integration as integration
+from pyro import compressible
+from pyro.mesh import integration
 
 
 class Simulation(compressible.Simulation):

--- a/pyro/compressible_sdc/simulation.py
+++ b/pyro/compressible_sdc/simulation.py
@@ -4,8 +4,8 @@ using SDC time integration
 """
 
 
-import pyro.compressible_fv4 as compressible_fv4
-import pyro.mesh.patch as patch
+from pyro import compressible_fv4
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/BC.py
+++ b/pyro/compressible_sr/BC.py
@@ -14,8 +14,8 @@ import math
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
 import pyro.compressible_sr.unsplit_fluxes as flx
+from pyro.compressible_sr import eos
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/c2p.py
+++ b/pyro/compressible_sr/c2p.py
@@ -5,7 +5,7 @@ from numba import njit
 @njit(cache=True)
 def f(p, U_ij, gamma, idens, ixmom, iymom, iener):
     """
-    Function whose root needs to be found for cons to prim 
+    Function whose root needs to be found for cons to prim
     """
 
     D = U_ij[idens]
@@ -18,14 +18,14 @@ def f(p, U_ij, gamma, idens, ixmom, iymom, iener):
         u = U_ij[ixmom] / (tau + p + D)
         v = U_ij[iymom] / (tau + p + D)
 
-    # Lorentz factor 
+    # Lorentz factor
     W = 1.0 / np.sqrt(1.0 - u**2 - v**2)
 
     return (gamma - 1.0) * (tau + D*(1.0-W) + p*(1.0-W**2)) / W**2 - p
 
 
 @njit(cache=True)
-def brentq(x1, b, U, gamma, idens, ixmom, iymom, iener, 
+def brentq(x1, b, U, gamma, idens, ixmom, iymom, iener,
            TOL=1.e-6, ITMAX=100):
     """
     Root finder using Brent's method
@@ -41,20 +41,20 @@ def brentq(x1, b, U, gamma, idens, ixmom, iymom, iener,
 
     # root found
     if fa * fb >= 0.0:
-        return x1 
+        return x1
 
-    # switch variables 
+    # switch variables
     if abs(fa) < abs(fb):
         d = a
-        a = b 
-        b = d 
+        a = b
+        b = d
 
-        d = fa 
+        d = fa
         fa = fb
-        fb = d 
+        fb = d
 
-    c = a 
-    fc = fa 
+    c = a
+    fc = fa
 
     mflag = True
 
@@ -66,65 +66,65 @@ def brentq(x1, b, U, gamma, idens, ixmom, iymom, iener,
             s = b - fb * (b-a) / (fb-fa)
 
         # test conditions and store in con1-con5
-        con1 = False 
+        con1 = False
 
         if 0.25 * (3.0 * a + b) < b:
             if s < 0.25 * (3.0 * a + b) or s > b:
-                con1 = True 
+                con1 = True
         elif s < b or s > 0.25 * (3.0 * a + b):
-            con1 = True 
+            con1 = True
 
         con2 = mflag and abs(s-b) >= 0.5 * abs(b-c)
 
         con3 = (not mflag) and abs(s-b) >= 0.5 * abs(c-d)
 
-        con4 = mflag and abs(b-c) < TOL 
+        con4 = mflag and abs(b-c) < TOL
 
-        con5 = (not mflag) and abs(c-d) < TOL 
+        con5 = (not mflag) and abs(c-d) < TOL
 
         if con1 or con2 or con3 or con4 or con5:
             s = 0.5 * (a + b)
-            mflag = True 
+            mflag = True
         else:
-            mflag = False 
+            mflag = False
 
-        # evaluate at midpoint and set new limits 
+        # evaluate at midpoint and set new limits
         fs = f(s, U, gamma, idens, ixmom, iymom, iener)
 
         if abs(fa) < abs(fb):
             d = a
-            a = b 
-            b = d 
+            a = b
+            b = d
 
-            d = fa 
-            fa = fb 
-            fb = d 
+            d = fa
+            fa = fb
+            fb = d
 
-        d = c 
-        c = b 
+        d = c
+        c = b
         fc = fb
 
         if fa * fs < 0.0:
-            b = s 
-            fb = fs 
+            b = s
+            fb = fs
         else:
-            a = s 
-            fa = fs 
+            a = s
+            fa = fs
 
         # found solution to required tolerance
         if fb == 0.0 or fs == 0.0 or abs(b-a) < TOL:
-            return b 
+            return b
 
-    return x1 
+    return x1
 
 
 @njit(cache=True)
-def cons_to_prim(U, 
-                 irho, iu, iv, ip, ix, irhox, 
-                 idens, ixmom, iymom, iener, 
+def cons_to_prim(U,
+                 irho, iu, iv, ip, ix, irhox,
+                 idens, ixmom, iymom, iener,
                  naux, gamma, q, smallp=1.e-6):
     """
-    convert an input vector of conserved variables to primitive variables 
+    convert an input vector of conserved variables to primitive variables
     """
 
     qx, qy, _ = U.shape
@@ -141,7 +141,7 @@ def cons_to_prim(U,
 
             if fmin * fmax > 0.0:
                 pmin = pmin * 1.0e-2
-                fmin = f(pmin, U[i, j, :], gamma, idens, ixmom, iymom, iener)    
+                fmin = f(pmin, U[i, j, :], gamma, idens, ixmom, iymom, iener)
 
             if fmin * fmax > 0.0:
                 pmax = min(pmax*1.0e2, 1.0)

--- a/pyro/compressible_sr/derives.py
+++ b/pyro/compressible_sr/derives.py
@@ -54,5 +54,4 @@ def derive_primitives(myd, varnames, ivars, myg):
             derived_vars.append(np.sqrt(gamma*p/dens))
     if len(derived_vars) > 1:
         return derived_vars
-    else:
-        return derived_vars[0]
+    return derived_vars[0]

--- a/pyro/compressible_sr/derives.py
+++ b/pyro/compressible_sr/derives.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
 import pyro.compressible_sr.unsplit_fluxes as flx
+from pyro.compressible_sr import eos
 
 
 def derive_primitives(myd, varnames, ivars, myg):

--- a/pyro/compressible_sr/interface.py
+++ b/pyro/compressible_sr/interface.py
@@ -4,7 +4,7 @@ from numba import njit
 
 @njit(cache=True)
 def states(idir, ng, dx, dt,
-           irho, iu, iv, ip, iX, 
+           irho, iu, iv, ip, iX,
            idens, ixmom, iymom, iener, irhoX, nspec,
            gamma, qv, Uv, dUv):
     r"""
@@ -178,7 +178,7 @@ def states(idir, ng, dx, dt,
                 rvec[2, :ns] = [W*q[iv], 2.0*h*W**2*q[iu]*q[iv],
                 h*(1.0 + 2.0*W**2*q[iv]**2),
                     2*h*W**2*q[iv]-W*q[iv]]
-                rvec[3, :ns] = [1.0, h*W*Ap*e_val[3], h*W*q[iv], 
+                rvec[3, :ns] = [1.0, h*W*Ap*e_val[3], h*W*q[iv],
                                 h*W*Ap-1.0]
 
                 # now the species -- they only have a 1 in their corresponding slot
@@ -227,13 +227,13 @@ def states(idir, ng, dx, dt,
                     (2.0*h-1.0)*(q[iv]-Am*e_val[0]) + h * Am*e_val[0]]
                 lvec[3, :ns] = -lvec[3, :ns] * h**2 / Delta
 
-                rvec[0, :ns] = [1.0, h*W*q[iu], h*W*Am*e_val[0], 
+                rvec[0, :ns] = [1.0, h*W*q[iu], h*W*Am*e_val[0],
                                 h*W*Am-1.0]
-                rvec[1, :ns] = [W*q[iu], 
+                rvec[1, :ns] = [W*q[iu],
                     h*(1.0 + 2.0*W**2*q[iu]**2), 2.0*h*W**2*q[iu]*q[iv],
                     2*h*W**2*q[iu]-W*q[iu]]
                 rvec[2, :ns] = [1.0/W, q[iu], q[iv], 1.0-1.0/W]
-                rvec[3, :ns] = [1.0, h*W*q[iu], h*W*Ap*e_val[3], 
+                rvec[3, :ns] = [1.0, h*W*q[iu], h*W*Ap*e_val[3],
                                 h*W*Ap-1.0]
 
                 # now the species -- they only have a 1 in their corresponding slot
@@ -287,7 +287,7 @@ def states(idir, ng, dx, dt,
 
 @njit(cache=True)
 def riemann_cgf(idir, ng,
-                idens, ixmom, iymom, iener, irhoX, 
+                idens, ixmom, iymom, iener, irhoX,
                 irho, iu, iv, ip, iX, nspec,
                 lower_solid, upper_solid,
                 gamma, U_l, U_r, q_l, q_r):
@@ -368,11 +368,11 @@ def riemann_cgf(idir, ng,
 
             # un = normal velocity; ut = transverse velocity
             if idir == 1:
-                un_l = q_l[i, j, iu] 
-                ut_l = q_l[i, j, iv] 
+                un_l = q_l[i, j, iu]
+                ut_l = q_l[i, j, iv]
             else:
-                un_l = q_l[i, j, iv] 
-                ut_l = q_l[i, j, iu] 
+                un_l = q_l[i, j, iv]
+                ut_l = q_l[i, j, iu]
 
             p_l = q_l[i, j, ip]
             p_l = max(p_l, smallp)
@@ -381,11 +381,11 @@ def riemann_cgf(idir, ng,
             rho_r = q_r[i, j, irho]
 
             if idir == 1:
-                un_r = q_r[i, j, iu] 
-                ut_r = q_r[i, j, iv] 
+                un_r = q_r[i, j, iu]
+                ut_r = q_r[i, j, iv]
             else:
                 un_r = q_r[i, j, iv]
-                ut_r = q_r[i, j, iu] 
+                ut_r = q_r[i, j, iu]
 
             p_r = q_r[i, j, ip]
             p_r = max(p_r, smallp)
@@ -499,7 +499,7 @@ def riemann_cgf(idir, ng,
 
                 v2 = ustar**2 + ut_r**2
                 lambdastar_r = 1.0 / (1.0 - v2*cstar_r**2) * (ustar*(1.0-cstar_r**2) + cstar_r *
-                                      np.sqrt((1.0-v2) * 
+                                      np.sqrt((1.0-v2) *
                                       (1.0 - v2*cstar_r**2 - ustar**2*(1.0-cstar_r**2))))
 
                 if pstar > p_r:
@@ -559,9 +559,9 @@ def riemann_cgf(idir, ng,
             # species now
             if nspec > 0:
                 if ustar > 0.0:
-                    xn = q_l[i, j, iX:iX + nspec] 
+                    xn = q_l[i, j, iX:iX + nspec]
                 elif ustar < 0.0:
-                    xn = q_r[i, j, iX:iX + nspec] 
+                    xn = q_r[i, j, iX:iX + nspec]
                 else:
                     xn = 0.5 * (q_l[i, j, iX:iX + nspec] +
                                 q_r[i, j, iX:iX + nspec])
@@ -581,26 +581,26 @@ def riemann_cgf(idir, ng,
                 if (j == jhi + 1 and upper_solid == 1):
                     un_state = 0.0
 
-            # Make primitive state 
-            q[irho] = rho_state 
+            # Make primitive state
+            q[irho] = rho_state
             if idir == 1:
-                q[iu] = un_state 
+                q[iu] = un_state
                 q[iv] = ut_state
             else:
-                q[iu] = ut_state 
-                q[iv] = un_state 
+                q[iu] = ut_state
+                q[iv] = un_state
 
-            q[ip] = p_state 
+            q[ip] = p_state
 
-            # Make conservative state 
+            # Make conservative state
             W = 1.0 / np.sqrt(1.0 - q[iu]**2 - q[iv]**2)
-            U[idens] = rho_state * W 
+            U[idens] = rho_state * W
             U[ixmom] = (rho_state + p_state * gamma / (gamma - 1.0)) * q[iu] * W**2
             U[iymom] = (rho_state + p_state * gamma / (gamma - 1.0)) * q[iv] * W**2
             U[iener] = (rho_state + p_state * gamma / (gamma - 1.0)) * W**2 - p_state - U[idens]
 
             if nspec > 0:
-                q[iX:iX+nspec] = xn 
+                q[iX:iX+nspec] = xn
                 U[irhoX:irhoX+nspec] = xn * U[idens]
 
             # compute the fluxes
@@ -750,12 +750,12 @@ def riemann_prim(idir, ng,
                 # define eigenvalues
                 v2 = un_l**2 + ut_l**2
                 lambda_l = 1.0 / (1.0 - v2*c_l**2) * (un_l*(1.0-c_l**2) - c_l *
-                                  np.sqrt((1.0-v2) * 
+                                  np.sqrt((1.0-v2) *
                                   (1.0-v2*c_l**2 - un_l**2*(1.0-c_l**2))))
 
                 v2 = ustar**2 + ut_l**2
                 lambdastar_l = 1.0 / (1.0 - v2*cstar_l**2) * \
-                    (ustar*(1.0-cstar_l**2) - cstar_l * np.sqrt((1.0-v2) * 
+                    (ustar*(1.0-cstar_l**2) - cstar_l * np.sqrt((1.0-v2) *
                     (1.0-v2*cstar_l**2 - ustar**2*(1.0-cstar_l**2))))
 
                 if pstar > p_l:
@@ -906,7 +906,7 @@ def riemann_prim(idir, ng,
 
 @njit(cache=True)
 def riemann_hllc(idir, ng,
-                 idens, ixmom, iymom, iener, irhoX, 
+                 idens, ixmom, iymom, iener, irhoX,
                  irho, iu, iv, ip, iX, nspec,
                  lower_solid, upper_solid,
                  gamma, U_l, U_r, q_l, q_r):
@@ -963,19 +963,19 @@ def riemann_hllc(idir, ng,
             # un = normal velocity; ut = transverse velocity
             if idir == 1:
                 un_l = q_l[i, j, iu]
-                ut_l = q_l[i, j, iv] 
+                ut_l = q_l[i, j, iv]
             else:
                 un_l = q_l[i, j, iv]
-                ut_l = q_l[i, j, iu] 
+                ut_l = q_l[i, j, iu]
 
             p_l = q_l[i, j, ip]
             p_l = max(p_l, smallp)
 
             if idir == 1:
-                un_r = q_r[i, j, iu] 
+                un_r = q_r[i, j, iu]
                 ut_r = q_r[i, j, iv]
             else:
-                un_r = q_r[i, j, iv] 
+                un_r = q_r[i, j, iv]
                 ut_r = q_r[i, j, iu]
 
             p_r = q_r[i, j, ip]
@@ -1001,11 +1001,11 @@ def riemann_hllc(idir, ng,
 
             F_HLLE = (a_r*F_l - a_l*F_r + a_r*a_l*(U_r[i, j, :] - U_l[i, j, :])) / (a_r - a_l)
 
-            if a_r <= 0.0:  # right state 
+            if a_r <= 0.0:  # right state
                 U_HLLE = U_r[i, j, :]
-            elif a_l < 0.0:  # middle 
+            elif a_l < 0.0:  # middle
                 U_HLLE = (a_r*U_r[i, j, :] - a_l*U_l[i, j, :] - F_r+F_l) / (a_r - a_l)
-            else:  # left 
+            else:  # left
                 U_HLLE = U_l[i, j, :]
 
             if idir == 1:
@@ -1027,10 +1027,10 @@ def riemann_hllc(idir, ng,
             if a_star != a_star:
                 a_star = 0.0
 
-            # left 
+            # left
             if idir == 1:
                 A = (U_l[i, j, iener] + U_l[i, j, idens]) * a_l - U_l[i, j, ixmom]
-                B = U_l[i, j, ixmom] * (a_l - un_l) - p_l 
+                B = U_l[i, j, ixmom] * (a_l - un_l) - p_l
             else:
                 A = (U_l[i, j, iener] + U_l[i, j, idens]) * a_l - U_l[i, j, iymom]
                 B = U_l[i, j, iymom] * (a_l - un_l) - p_l
@@ -1046,7 +1046,7 @@ def riemann_hllc(idir, ng,
                 U_lstar[ixmom] = U_l[i, j, ixmom] * (a_l - un_l) / (a_l - a_star)
                 U_lstar[iymom] = (U_l[i, j, iymom] * (a_l - un_l) + p_lstar - p_l) / (a_l - a_star)
 
-            # species 
+            # species
             if nspec > 0:
                 U_lstar[irhoX:irhoX+nspec] = U_l[i, j, irhoX:irhoX+nspec] * (a_l - un_l) / (a_l - a_star)
 
@@ -1069,34 +1069,34 @@ def riemann_hllc(idir, ng,
                 U_rstar[ixmom] = U_r[i, j, ixmom] * (a_r - un_r) / (a_r - a_star)
                 U_rstar[iymom] = (U_r[i, j, iymom] * (a_r - un_r) + p_rstar - p_r) / (a_r - a_star)
 
-            # species 
+            # species
             if nspec > 0:
                 U_rstar[irhoX:irhoX+nspec] = U_r[i, j, irhoX:irhoX+nspec] * (a_r - un_r) / (a_r - a_star)
 
-            if a_r <= 0.0:  # right state 
-                F[i, j, :] = F_r 
+            if a_r <= 0.0:  # right state
+                F[i, j, :] = F_r
 
             elif a_star <= 0.0:  # right star
-                F[i, j, :] = U_rstar * a_star 
+                F[i, j, :] = U_rstar * a_star
 
                 if idir == 1:
-                    F[i, j, ixmom] += p_rstar 
+                    F[i, j, ixmom] += p_rstar
                     F[i, j, iener] = U_rstar[ixmom] - F[i, j, idens]
                 else:
                     F[i, j, iymom] += p_rstar
                     F[i, j, iener] = U_rstar[iymom] - F[i, j, idens]
 
-            elif a_l < 0.0:  # left star 
-                F[i, j, :] = U_lstar * a_star 
+            elif a_l < 0.0:  # left star
+                F[i, j, :] = U_lstar * a_star
 
                 if idir == 1:
-                    F[i, j, ixmom] += p_lstar 
+                    F[i, j, ixmom] += p_lstar
                     F[i, j, iener] = U_lstar[ixmom] - F[i, j, idens]
                 else:
                     F[i, j, iymom] += p_lstar
                     F[i, j, iener] = U_lstar[iymom] - F[i, j, idens]
 
-            else:  # left 
+            else:  # left
                 F[i, j, :] = F_l
 
     return F

--- a/pyro/compressible_sr/interface.py
+++ b/pyro/compressible_sr/interface.py
@@ -132,7 +132,7 @@ def states(idir, ng, dx, dt,
             e_val[:] = 0.0
 
             # compute the eigenvalues and eigenvectors
-            if (idir == 1):
+            if idir == 1:
                 e_val[1:3] = np.array([q[iu], q[iu]])
 
                 e_val[0] = 1.0 / (1.0 - v2 * cs2) * \
@@ -243,7 +243,7 @@ def states(idir, ng, dx, dt,
                     rvec[n, n] = 1.0
 
             # define the reference states
-            if (idir == 1):
+            if idir == 1:
                 # this is one the right face of the current zone,
                 # so the fastest moving eigenvalue is e_val[3] = u + c
                 factor = 0.5 * (1.0 - dtdx * max(e_val[3], 0.0))
@@ -275,7 +275,7 @@ def states(idir, ng, dx, dt,
                 sum_l = np.dot(betal, rvec[:, m])
                 sum_r = np.dot(betar, rvec[:, m])
 
-                if (idir == 1):
+                if idir == 1:
                     U_l[i + 1, j, m] += sum_l
                     U_r[i,  j, m] += sum_r
                 else:
@@ -367,7 +367,7 @@ def riemann_cgf(idir, ng,
             rho_l = q_l[i, j, irho]
 
             # un = normal velocity; ut = transverse velocity
-            if (idir == 1):
+            if idir == 1:
                 un_l = q_l[i, j, iu] 
                 ut_l = q_l[i, j, iv] 
             else:
@@ -380,7 +380,7 @@ def riemann_cgf(idir, ng,
 
             rho_r = q_r[i, j, irho]
 
-            if (idir == 1):
+            if idir == 1:
                 un_r = q_r[i, j, iu] 
                 ut_r = q_r[i, j, iv] 
             else:
@@ -420,7 +420,7 @@ def riemann_cgf(idir, ng,
 
             # figure out which state we are in, based on the location of
             # the waves
-            if (ustar > 0.0):
+            if ustar > 0.0:
 
                 # contact is moving to the right, we need to understand
                 # the L and *L states
@@ -438,11 +438,11 @@ def riemann_cgf(idir, ng,
                     (ustar * (1.0 - cstar_l**2) - cstar_l * np.sqrt((1.0 - v2) *
                      (1.0 - v2*cstar_l**2 - ustar**2*(1.0-cstar_l**2))))
 
-                if (pstar > p_l):
+                if pstar > p_l:
                     # the wave is a shock -- find the shock speed
                     sigma = (lambda_l + lambdastar_l) / 2.0
 
-                    if (sigma > 0.0):
+                    if sigma > 0.0:
                         # shock is moving to the right -- solution is L state
                         rho_state = rho_l
                         un_state = un_l
@@ -567,14 +567,14 @@ def riemann_cgf(idir, ng,
                                 q_r[i, j, iX:iX + nspec])
 
             # are we on a solid boundary?
-            if (idir == 1):
+            if idir == 1:
                 if (i == ilo and lower_solid == 1):
                     un_state = 0.0
 
                 if (i == ihi + 1 and upper_solid == 1):
                     un_state = 0.0
 
-            elif (idir == 2):
+            elif idir == 2:
                 if (j == jlo and lower_solid == 1):
                     un_state = 0.0
 
@@ -583,7 +583,7 @@ def riemann_cgf(idir, ng,
 
             # Make primitive state 
             q[irho] = rho_state 
-            if (idir == 1):
+            if idir == 1:
                 q[iu] = un_state 
                 q[iv] = ut_state
             else:
@@ -691,7 +691,7 @@ def riemann_prim(idir, ng,
             rho_l = q_l[i, j, irho]
 
             # un = normal velocity; ut = transverse velocity
-            if (idir == 1):
+            if idir == 1:
                 un_l = q_l[i, j, iu]
                 ut_l = q_l[i, j, iv]
             else:
@@ -703,7 +703,7 @@ def riemann_prim(idir, ng,
 
             rho_r = q_r[i, j, irho]
 
-            if (idir == 1):
+            if idir == 1:
                 un_r = q_r[i, j, iu]
                 ut_r = q_r[i, j, iv]
             else:
@@ -864,24 +864,24 @@ def riemann_prim(idir, ng,
 
             # species now
             if nspec > 0:
-                if (ustar > 0.0):
+                if ustar > 0.0:
                     xn = q_l[i, j, iX:iX + nspec]
 
-                elif (ustar < 0.0):
+                elif ustar < 0.0:
                     xn = q_r[i, j, iX:iX + nspec]
                 else:
                     xn = 0.5 * (q_l[i, j, iX:iX + nspec] +
                                    q_r[i, j, iX:iX + nspec])
 
             # are we on a solid boundary?
-            if (idir == 1):
+            if idir == 1:
                 if (i == ilo and lower_solid == 1):
                     un_state = 0.0
 
                 if (i == ihi + 1 and upper_solid == 1):
                     un_state = 0.0
 
-            elif (idir == 2):
+            elif idir == 2:
                 if (j == jlo and lower_solid == 1):
                     un_state = 0.0
 
@@ -889,7 +889,7 @@ def riemann_prim(idir, ng,
                     un_state = 0.0
 
             q_int[i, j, irho] = rho_state
-            if (idir == 1):
+            if idir == 1:
                 q_int[i, j, iu] = un_state
                 q_int[i, j, iv] = ut_state
             else:
@@ -961,7 +961,7 @@ def riemann_hllc(idir, ng,
         for j in range(jlo - 1, jhi + 1):
 
             # un = normal velocity; ut = transverse velocity
-            if (idir == 1):
+            if idir == 1:
                 un_l = q_l[i, j, iu]
                 ut_l = q_l[i, j, iv] 
             else:
@@ -971,7 +971,7 @@ def riemann_hllc(idir, ng,
             p_l = q_l[i, j, ip]
             p_l = max(p_l, smallp)
 
-            if (idir == 1):
+            if idir == 1:
                 un_r = q_r[i, j, iu] 
                 ut_r = q_r[i, j, iv]
             else:
@@ -1134,7 +1134,7 @@ def consFlux(idir, gamma, idens, ixmom, iymom, iener, irhoX, iu, iv, ip, nspec, 
 
     p = q_state[ip]
 
-    if (idir == 1):
+    if idir == 1:
         F[idens] = U_state[idens] * u
         F[ixmom] = U_state[ixmom] * u + p
         F[iymom] = U_state[iymom] * u

--- a/pyro/compressible_sr/problems/acoustic_pulse.py
+++ b/pyro/compressible_sr/problems/acoustic_pulse.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
+from pyro.compressible_sr import eos
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/acoustic_pulse.py
+++ b/pyro/compressible_sr/problems/acoustic_pulse.py
@@ -59,4 +59,3 @@ def init_data(myd, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/advect.py
+++ b/pyro/compressible_sr/problems/advect.py
@@ -2,8 +2,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/bubble.py
+++ b/pyro/compressible_sr/problems/bubble.py
@@ -2,8 +2,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/bubble.py
+++ b/pyro/compressible_sr/problems/bubble.py
@@ -97,4 +97,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/gresho.py
+++ b/pyro/compressible_sr/problems/gresho.py
@@ -86,4 +86,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the userad at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/gresho.py
+++ b/pyro/compressible_sr/problems/gresho.py
@@ -2,8 +2,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/hse.py
+++ b/pyro/compressible_sr/problems/hse.py
@@ -65,4 +65,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/hse.py
+++ b/pyro/compressible_sr/problems/hse.py
@@ -2,8 +2,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/kh.py
+++ b/pyro/compressible_sr/problems/kh.py
@@ -86,4 +86,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/kh.py
+++ b/pyro/compressible_sr/problems/kh.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/logo.py
+++ b/pyro/compressible_sr/problems/logo.py
@@ -3,8 +3,8 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/quad.py
+++ b/pyro/compressible_sr/problems/quad.py
@@ -109,4 +109,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/quad.py
+++ b/pyro/compressible_sr/problems/quad.py
@@ -2,8 +2,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/rt.py
+++ b/pyro/compressible_sr/problems/rt.py
@@ -80,4 +80,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/rt.py
+++ b/pyro/compressible_sr/problems/rt.py
@@ -2,8 +2,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/rt.py
+++ b/pyro/compressible_sr/problems/rt.py
@@ -52,7 +52,7 @@ def init_data(my_data, rp):
     dens[:, :] = dens1
 
     for j in range(myg.jlo, myg.jhi+1):
-        if (myg.y[j] < ycenter):
+        if myg.y[j] < ycenter:
             dens[:, j] = dens1
             p[:, j] = p0 + dens1*grav*myg.y[j]
 

--- a/pyro/compressible_sr/problems/rt2.py
+++ b/pyro/compressible_sr/problems/rt2.py
@@ -60,7 +60,7 @@ def init_data(my_data, rp):
 
     j = myg.jlo
     while j <= myg.jhi:
-        if (myg.y[j] < ycenter):
+        if myg.y[j] < ycenter:
             dens[:, j] = dens1
             p[:, j] = p0 + dens1*grav*myg.y[j]
 

--- a/pyro/compressible_sr/problems/rt2.py
+++ b/pyro/compressible_sr/problems/rt2.py
@@ -92,4 +92,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/problems/rt2.py
+++ b/pyro/compressible_sr/problems/rt2.py
@@ -8,8 +8,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/sedov.py
+++ b/pyro/compressible_sr/problems/sedov.py
@@ -3,8 +3,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/sod.py
+++ b/pyro/compressible_sr/problems/sod.py
@@ -2,8 +2,8 @@ import sys
 
 import numpy as np
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/problems/test.py
+++ b/pyro/compressible_sr/problems/test.py
@@ -1,7 +1,7 @@
 import sys
 
-import pyro.compressible_sr.eos as eos
-import pyro.mesh.patch as patch
+from pyro.compressible_sr import eos
+from pyro.mesh import patch
 
 
 def init_data(my_data, rp):

--- a/pyro/compressible_sr/problems/test.py
+++ b/pyro/compressible_sr/problems/test.py
@@ -41,4 +41,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/compressible_sr/simulation.py
+++ b/pyro/compressible_sr/simulation.py
@@ -3,13 +3,11 @@ import importlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.compressible_sr.BC as BC
-import pyro.compressible_sr.derives as derives
-import pyro.compressible_sr.eos as eos
 import pyro.compressible_sr.unsplit_fluxes as flx
 import pyro.mesh.boundary as bnd
-import pyro.util.plot_tools as plot_tools
+from pyro.compressible_sr import BC, derives, eos
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
+from pyro.util import plot_tools
 
 # np.seterr(all='raise')
 

--- a/pyro/compressible_sr/unsplit_fluxes.py
+++ b/pyro/compressible_sr/unsplit_fluxes.py
@@ -122,10 +122,10 @@ Updating U_{i,j}:
 
 """
 
-import pyro.compressible_sr.c2p as c2p
 import pyro.compressible_sr.interface as ifc
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.reconstruction as reconstruction
+from pyro.compressible_sr import c2p
+from pyro.mesh import reconstruction
 from pyro.util import msg
 
 

--- a/pyro/compressible_sr/unsplit_fluxes.py
+++ b/pyro/compressible_sr/unsplit_fluxes.py
@@ -456,7 +456,7 @@ def cons_to_prim_wrapper(U, gamma, ivars, myg):
 
     q = myg.scratch_array(nvar=ivars.nq)
 
-    c2p.cons_to_prim(U, ivars.irho, 
+    c2p.cons_to_prim(U, ivars.irho,
                      ivars.iu, ivars.iv,
                      ivars.ip, ivars.ix, ivars.irhox,
                      ivars.idens, ivars.ixmom, ivars.iymom,

--- a/pyro/diffusion/problems/gaussian.py
+++ b/pyro/diffusion/problems/gaussian.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/diffusion/problems/test.py
+++ b/pyro/diffusion/problems/test.py
@@ -19,4 +19,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/diffusion/problems/test.py
+++ b/pyro/diffusion/problems/test.py
@@ -1,6 +1,6 @@
 import sys
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 
 
 def init_data(my_data, rp):

--- a/pyro/diffusion/simulation.py
+++ b/pyro/diffusion/simulation.py
@@ -7,8 +7,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.mesh.patch as patch
-import pyro.multigrid.MG as MG
+from pyro.mesh import patch
+from pyro.multigrid import MG
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
 from pyro.util import msg
 

--- a/pyro/incompressible/problems/converge.py
+++ b/pyro/incompressible/problems/converge.py
@@ -28,7 +28,7 @@ import math
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/incompressible/problems/shear.py
+++ b/pyro/incompressible/problems/shear.py
@@ -65,4 +65,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/incompressible/problems/shear.py
+++ b/pyro/incompressible/problems/shear.py
@@ -18,7 +18,7 @@ import math
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/incompressible/simulation.py
+++ b/pyro/incompressible/simulation.py
@@ -3,12 +3,11 @@ import importlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.incompressible.incomp_interface as incomp_interface
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.patch as patch
-import pyro.mesh.reconstruction as reconstruction
-import pyro.multigrid.MG as MG
-import pyro.particles.particles as particles
+from pyro.incompressible import incomp_interface
+from pyro.mesh import patch, reconstruction
+from pyro.multigrid import MG
+from pyro.particles import particles
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
 
 

--- a/pyro/incompressible/simulation.py
+++ b/pyro/incompressible/simulation.py
@@ -45,6 +45,8 @@ class Simulation(NullSimulation):
             particle_generator = self.rp.get_param("particles.particle_generator")
             self.particles = particles.Particles(self.cc_data, bc, n_particles, particle_generator)
 
+        self.in_preevolve = False
+
         # now set the initial conditions for the problem
         problem = importlib.import_module(f"pyro.incompressible.problems.{self.problem_name}")
         problem.init_data(self.cc_data, self.rp)

--- a/pyro/lm_atm/LM_atm_interface.py
+++ b/pyro/lm_atm/LM_atm_interface.py
@@ -33,7 +33,7 @@ def is_symmetric_pair(ng, nodal, sl, sr):
 
     sym = 1
 
-    if (not nodal):
+    if not nodal:
         done = False
         for i in range(nx / 2):
             il = ilo + i
@@ -120,7 +120,7 @@ def is_asymmetric_pair(ng, nodal, sl, sr):
 
     asym = 1
 
-    if (not nodal):
+    if not nodal:
         done = False
         for i in range(nx / 2):
             for j in range(jlo, jhi):

--- a/pyro/lm_atm/problems/bubble.py
+++ b/pyro/lm_atm/problems/bubble.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/lm_atm/problems/bubble.py
+++ b/pyro/lm_atm/problems/bubble.py
@@ -76,4 +76,3 @@ def init_data(my_data, base, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/lm_atm/problems/gresho.py
+++ b/pyro/lm_atm/problems/gresho.py
@@ -86,4 +86,3 @@ def init_data(my_data, base, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/lm_atm/problems/gresho.py
+++ b/pyro/lm_atm/problems/gresho.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/lm_atm/simulation.py
+++ b/pyro/lm_atm/simulation.py
@@ -524,7 +524,7 @@ class Simulation(NullSimulation):
         # add the gravitational source
         rho_half = 0.5*(rho + rho_old)
         rhoprime = self.make_prime(rho_half, rho0)
-        source[:, :] = (rhoprime*g/rho_half)
+        source[:, :] = rhoprime*g/rho_half
         self.aux_data.fill_BC("source_y")
 
         v[:, :] += self.dt*source

--- a/pyro/lm_atm/simulation.py
+++ b/pyro/lm_atm/simulation.py
@@ -6,9 +6,8 @@ import numpy as np
 import pyro.lm_atm.LM_atm_interface as lm_interface
 import pyro.mesh.array_indexer as ai
 import pyro.mesh.boundary as bnd
-import pyro.mesh.patch as patch
-import pyro.mesh.reconstruction as reconstruction
 import pyro.multigrid.variable_coeff_MG as vcMG
+from pyro.mesh import patch, reconstruction
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
 
 

--- a/pyro/lm_atm/simulation.py
+++ b/pyro/lm_atm/simulation.py
@@ -43,6 +43,7 @@ class Simulation(NullSimulation):
 
         self.base = {}
         self.aux_data = None
+        self.in_preevolve = False
 
     def initialize(self):
         """

--- a/pyro/mesh/array_indexer.py
+++ b/pyro/mesh/array_indexer.py
@@ -47,7 +47,8 @@ class ArrayIndexer(np.ndarray):
         self.c = getattr(obj, "c", None)
 
     def __array_wrap__(self, out_arr, context=None):
-        return np.ndarray.__array_wrap__(self, out_arr, context)  # pylint: disable=E1121
+        # pylint: disable-next=too-many-function-args
+        return np.ndarray.__array_wrap__(self, out_arr, context)
 
     def v(self, buf=0, n=0, s=1):
         """return a view of the valid data region for component n, with stride
@@ -358,7 +359,8 @@ class ArrayIndexerFC(ArrayIndexer):
         self.c = getattr(obj, "c", None)
 
     def __array_wrap__(self, out_arr, context=None):
-        return np.ndarray.__array_wrap__(self, out_arr, context)  # pylint: disable=E1121
+        # pylint: disable-next=too-many-function-args
+        return np.ndarray.__array_wrap__(self, out_arr, context)
 
     def ip_jp(self, ishift, jshift, buf=0, n=0, s=1):
         """return a view of the data shifted by ishift in the x direction and

--- a/pyro/mesh/array_indexer.py
+++ b/pyro/mesh/array_indexer.py
@@ -371,7 +371,7 @@ class ArrayIndexerFC(ArrayIndexer):
         bxlo, bxhi, bylo, byhi = _buf_split(buf)
         c = len(self.shape)
 
-        if self.idir == 1:
+        if self.idir == 1:  # pylint: disable=no-else-return
             # face-centered in x
             if c == 2:
                 return np.asarray(self[self.g.ilo-bxlo+ishift:self.g.ihi+2+bxhi+ishift:s,
@@ -449,7 +449,7 @@ class ArrayIndexerFC(ArrayIndexer):
         # -x boundary
         if bc.xlb in ["outflow", "neumann", "reflect-even", "reflect-odd", "dirichlet"]:
             raise NotImplementedError("boundary condition not implemented for -x")
-        elif bc.xlb == "periodic":
+        if bc.xlb == "periodic":
             if self.idir == 1:
                 # face-centered in x
                 for i in range(self.g.ilo):
@@ -462,7 +462,7 @@ class ArrayIndexerFC(ArrayIndexer):
         # +x boundary
         if bc.xrb in ["outflow", "neumann", "reflect-even", "reflect-odd", "dirichlet"]:
             raise NotImplementedError("boundary condition not implemented for +x")
-        elif bc.xrb == "periodic":
+        if bc.xrb == "periodic":
             if self.idir == 1:
                 # face-centered in x
                 for i in range(self.g.ihi+2, 2*self.g.ng + self.g.nx + 1):
@@ -475,7 +475,7 @@ class ArrayIndexerFC(ArrayIndexer):
         # -y boundary
         if bc.ylb in ["outflow", "neumann", "reflect-even", "reflect-odd", "dirichlet"]:
             raise NotImplementedError("boundary condition not implemented for -y")
-        elif bc.ylb == "periodic":
+        if bc.ylb == "periodic":
             if self.idir == 1:
                 # face-centered in x
                 for j in range(self.g.jlo):
@@ -488,7 +488,7 @@ class ArrayIndexerFC(ArrayIndexer):
         # +y boundary
         if bc.yrb in ["outflow", "neumann", "reflect-even", "reflect-odd", "dirichlet"]:
             raise NotImplementedError("boundary condition not implemented for +y")
-        elif bc.yrb == "periodic":
+        if bc.yrb == "periodic":
             if self.idir == 1:
                 # face-centered in x
                 for j in range(self.g.jhi+1, 2*self.g.ng + self.g.ny):

--- a/pyro/mesh/integration.py
+++ b/pyro/mesh/integration.py
@@ -24,7 +24,7 @@ and the s increment is::
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 
 a = {}
 b = {}

--- a/pyro/mesh/patch.py
+++ b/pyro/mesh/patch.py
@@ -379,8 +379,7 @@ class CellCenterData2d:
                 if len(var) > 0:
                     return var
             raise KeyError(f"name {name} is not valid")
-        else:
-            return self.get_var_by_index(n)
+        return self.get_var_by_index(n)
 
     def get_var_by_index(self, n):
         """

--- a/pyro/multigrid/MG.py
+++ b/pyro/multigrid/MG.py
@@ -70,7 +70,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pyro.mesh.boundary as bnd
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/multigrid/MG.py
+++ b/pyro/multigrid/MG.py
@@ -428,13 +428,13 @@ class CellCenterMG2d:
 
         if grid is None:
             return v.copy()
-        else:
-            myg = self.soln_grid
-            assert grid.dx == myg.dx and grid.dy == myg.dy
 
-            sol = grid.scratch_array()
-            sol.v(buf=1)[:, :] = v.v(buf=1)
-            return sol
+        myg = self.soln_grid
+        assert grid.dx == myg.dx and grid.dy == myg.dy
+
+        sol = grid.scratch_array()
+        sol.v(buf=1)[:, :] = v.v(buf=1)
+        return sol
 
     def get_solution_gradient(self, grid=None):
         """

--- a/pyro/multigrid/general_MG.py
+++ b/pyro/multigrid/general_MG.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pyro.multigrid.edge_coeffs as ec
-import pyro.multigrid.MG as MG
+from pyro.multigrid import MG
 
 np.set_printoptions(precision=3, linewidth=128)
 

--- a/pyro/multigrid/variable_coeff_MG.py
+++ b/pyro/multigrid/variable_coeff_MG.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pyro.multigrid.edge_coeffs as ec
-import pyro.multigrid.MG as MG
+from pyro.multigrid import MG
 
 np.set_printoptions(precision=3, linewidth=128)
 

--- a/pyro/particles/particles.py
+++ b/pyro/particles/particles.py
@@ -282,7 +282,7 @@ class Particles:
             if p.x < myg.xmin:
                 if xlb in ["outflow", "neumann"]:
                     continue
-                elif xlb == "periodic":
+                if xlb == "periodic":
                     p.x = myg.xmax + p.x - myg.xmin
                 elif xlb in ["reflect-even", "reflect-odd", "dirichlet"]:
                     p.x = 2 * myg.xmin - p.x
@@ -293,7 +293,7 @@ class Particles:
             if p.x > myg.xmax:
                 if xrb in ["outflow", "neumann"]:
                     continue
-                elif xrb == "periodic":
+                if xrb == "periodic":
                     p.x = myg.xmin + p.x - myg.xmax
                 elif xrb in ["reflect-even", "reflect-odd", "dirichlet"]:
                     p.x = 2 * myg.xmax - p.x
@@ -304,7 +304,7 @@ class Particles:
             if p.y < myg.ymin:
                 if ylb in ["outflow", "neumann"]:
                     continue
-                elif ylb == "periodic":
+                if ylb == "periodic":
                     p.y = myg.ymax + p.y - myg.ymin
                 elif ylb in ["reflect-even", "reflect-odd", "dirichlet"]:
                     p.y = 2 * myg.ymin - p.y
@@ -315,7 +315,7 @@ class Particles:
             if p.y > myg.ymax:
                 if yrb in ["outflow", "neumann"]:
                     continue
-                elif yrb == "periodic":
+                if yrb == "periodic":
                     p.y = myg.ymin + p.y - myg.ymax
                 elif yrb in ["reflect-even", "reflect-odd", "dirichlet"]:
                     p.y = 2 * myg.ymax - p.y

--- a/pyro/pyro_sim.py
+++ b/pyro/pyro_sim.py
@@ -87,6 +87,7 @@ class Pyro:
         other_commands : str
             Other command line parameter options
         """
+        # pylint: disable=attribute-defined-outside-init
 
         problem_defaults_file = self.pyro_home + self.solver_name + \
             "/problems/_" + problem_name + ".defaults"

--- a/pyro/pyro_sim.py
+++ b/pyro/pyro_sim.py
@@ -289,8 +289,7 @@ class PyroBenchmark(Pyro):
 
         if self.comp_bench:
             return result
-        else:
-            return self.sim
+        return self.sim
 
     def compare_to_benchmark(self, rtol):
         """ Are we comparing to a benchmark? """

--- a/pyro/simulation_null.py
+++ b/pyro/simulation_null.py
@@ -3,8 +3,8 @@ import importlib
 import h5py
 
 import pyro.mesh.boundary as bnd
-import pyro.mesh.patch as patch
 import pyro.util.profile_pyro as profile
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/simulation_null.py
+++ b/pyro/simulation_null.py
@@ -160,8 +160,7 @@ class NullSimulation(object):
         if is_time and do_io == 1:
             self.n_num_out += 1
             return True
-        else:
-            return False
+        return False
 
     def initialize(self):
         pass

--- a/pyro/simulation_null.py
+++ b/pyro/simulation_null.py
@@ -169,7 +169,6 @@ class NullSimulation(object):
         """
         the method-specific timestep code
         """
-        pass
 
     def compute_timestep(self):
         """
@@ -200,7 +199,6 @@ class NullSimulation(object):
         Do any necessary evolution before the main evolve loop.  This
         is not needed for advection
         """
-        pass
 
     def evolve(self):
 
@@ -247,10 +245,8 @@ class NullSimulation(object):
         """
         write out any extra simulation-specific stuff
         """
-        pass
 
     def read_extras(self, f):
         """
         read in any simulation-specific data from an h5py file object f
         """
-        pass

--- a/pyro/swe/derives.py
+++ b/pyro/swe/derives.py
@@ -39,5 +39,4 @@ def derive_primitives(myd, varnames):
 
     if len(derived_vars) > 1:
         return derived_vars
-    else:
-        return derived_vars[0]
+    return derived_vars[0]

--- a/pyro/swe/interface.py
+++ b/pyro/swe/interface.py
@@ -122,7 +122,7 @@ def states(idir, ng, dx, dt,
             e_val[:] = 0.0
 
             # compute the eigenvalues and eigenvectors
-            if (idir == 1):
+            if idir == 1:
                 e_val[:ns] = [q[iu] - cs, q[iu], q[iu] + cs]
 
                 lvec[0, :ns] = [cs, -q[ih], 0.0]
@@ -164,7 +164,7 @@ def states(idir, ng, dx, dt,
                 lvec[2, :] = -lvec[2, :] * 0.50 / (cs * q[ih])
 
             # define the reference states
-            if (idir == 1):
+            if idir == 1:
                 # this is one the right face of the current zone,
                 # so the fastest moving eigenvalue is e_val[2] = u + c
                 factor = 0.5 * (1.0 - dtdx * max(e_val[2], 0.0))
@@ -197,7 +197,7 @@ def states(idir, ng, dx, dt,
                 sum_l = np.dot(betal, rvec[:, m])
                 sum_r = np.dot(betar, rvec[:, m])
 
-                if (idir == 1):
+                if idir == 1:
                     q_l[i + 1, j, m] = q_l[i + 1, j, m] + sum_l
                     q_r[i,  j, m] = q_r[i,  j, m] + sum_r
                 else:
@@ -268,14 +268,14 @@ def riemann_roe(idir, ng,
             h_l = U_l[i, j, ih]
 
             # un = normal velocity; ut = transverse velocity
-            if (idir == 1):
+            if idir == 1:
                 un_l = U_l[i, j, ixmom] / h_l
             else:
                 un_l = U_l[i, j, iymom] / h_l
 
             h_r = U_r[i, j, ih]
 
-            if (idir == 1):
+            if idir == 1:
                 un_r = U_r[i, j, ixmom] / h_r
             else:
                 un_r = U_r[i, j, iymom] / h_r
@@ -295,7 +295,7 @@ def riemann_roe(idir, ng,
             delta[ih] = h_r - h_l
 
             # e_values and right evectors
-            if (idir == 1):
+            if idir == 1:
                 un_roe = U_roe[ixmom]
             else:
                 un_roe = U_roe[iymom]
@@ -303,7 +303,7 @@ def riemann_roe(idir, ng,
             K_roe[:, :] = 0.0
 
             lambda_roe[:3] = np.array([un_roe - c_roe, un_roe, un_roe + c_roe])
-            if (idir == 1):
+            if idir == 1:
                 alpha_roe[:3] = [0.5 * (delta[ih] - U_roe[ih] / c_roe * delta[ixmom]),
                                  U_roe[ih] * delta[iymom],
                                  0.5 * (delta[ih] + U_roe[ih] / c_roe * delta[ixmom])]
@@ -339,11 +339,11 @@ def riemann_roe(idir, ng,
             c_star = np.sqrt(g * h_star)
 
             # modified e_values for entropy fix
-            if (abs(lambda_roe[0]) < tol):
+            if abs(lambda_roe[0]) < tol:
                 lambda_roe[0] = lambda_roe[0] * (u_star - c_star - lambda_roe[0]) / \
                     (u_star - c_star - (un_l - c_l))
 
-            if (abs(lambda_roe[2]) < tol):
+            if abs(lambda_roe[2]) < tol:
                 lambda_roe[2] = lambda_roe[2] * (u_star + c_star - lambda_roe[2]) / \
                     (u_star + c_star - (un_r + c_r))
 
@@ -409,7 +409,7 @@ def riemann_hllc(idir, ng,
             h_l = U_l[i, j, ih]
 
             # un = normal velocity; ut = transverse velocity
-            if (idir == 1):
+            if idir == 1:
                 un_l = U_l[i, j, ixmom] / h_l
                 ut_l = U_l[i, j, iymom] / h_l
             else:
@@ -418,7 +418,7 @@ def riemann_hllc(idir, ng,
 
             h_r = U_r[i, j, ih]
 
-            if (idir == 1):
+            if idir == 1:
                 un_r = U_r[i, j, ixmom] / h_r
                 ut_r = U_r[i, j, iymom] / h_r
             else:
@@ -442,14 +442,14 @@ def riemann_hllc(idir, ng,
 
             # estimate the nonlinear wave speeds
 
-            if (hstar <= h_l):
+            if hstar <= h_l:
                 # rarefaction
                 S_l = un_l - c_l
             else:
                 # shock
                 S_l = un_l - c_l * np.sqrt(0.5 * (hstar + h_l) * hstar) / h_l
 
-            if (hstar <= h_r):
+            if hstar <= h_r:
                 # rarefaction
                 S_r = un_r + c_r
             else:
@@ -461,7 +461,7 @@ def riemann_hllc(idir, ng,
 
             # figure out which region we are in and compute the state and
             # the interface fluxes using the HLLC Riemann solver
-            if (S_r <= 0.0):
+            if S_r <= 0.0:
                 # R region
                 U_state[:] = U_r[i, j, :]
 
@@ -474,7 +474,7 @@ def riemann_hllc(idir, ng,
 
                 U_state[ih] = HLLCfactor
 
-                if (idir == 1):
+                if idir == 1:
                     U_state[ixmom] = HLLCfactor * S_c
                     U_state[iymom] = HLLCfactor * ut_r
                 else:
@@ -482,7 +482,7 @@ def riemann_hllc(idir, ng,
                     U_state[iymom] = HLLCfactor * S_c
 
                 # species
-                if (nspec > 0):
+                if nspec > 0:
                     U_state[ihX:ihX + nspec] = HLLCfactor * \
                         U_r[i, j, ihX:ihX + nspec] / h_r
 
@@ -499,7 +499,7 @@ def riemann_hllc(idir, ng,
 
                 U_state[ih] = HLLCfactor
 
-                if (idir == 1):
+                if idir == 1:
                     U_state[ixmom] = HLLCfactor * S_c
                     U_state[iymom] = HLLCfactor * ut_l
                 else:
@@ -507,7 +507,7 @@ def riemann_hllc(idir, ng,
                     U_state[iymom] = HLLCfactor * S_c
 
                 # species
-                if (nspec > 0):
+                if nspec > 0:
                     U_state[ihX:ihX + nspec] = HLLCfactor * \
                         U_l[i, j, ihX:ihX + nspec] / h_l
 
@@ -561,18 +561,18 @@ def consFlux(idir, g, ih, ixmom, iymom, ihX, nspec, U_state):
     u = U_state[ixmom] / U_state[ih]
     v = U_state[iymom] / U_state[ih]
 
-    if (idir == 1):
+    if idir == 1:
         F[ih] = U_state[ih] * u
         F[ixmom] = U_state[ixmom] * u + 0.5 * g * U_state[ih]**2
         F[iymom] = U_state[iymom] * u
-        if (nspec > 0):
+        if nspec > 0:
             F[ihX:ihX + nspec] = U_state[ihX:ihX + nspec] * u
 
     else:
         F[ih] = U_state[ih] * v
         F[ixmom] = U_state[ixmom] * v
         F[iymom] = U_state[iymom] * v + 0.5 * g * U_state[ih]**2
-        if (nspec > 0):
+        if nspec > 0:
             F[ihX:ihX + nspec] = U_state[ihX:ihX + nspec] * v
 
     return F

--- a/pyro/swe/problems/acoustic_pulse.py
+++ b/pyro/swe/problems/acoustic_pulse.py
@@ -52,4 +52,3 @@ def init_data(myd, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/swe/problems/acoustic_pulse.py
+++ b/pyro/swe/problems/acoustic_pulse.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/swe/problems/advect.py
+++ b/pyro/swe/problems/advect.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/swe/problems/dam.py
+++ b/pyro/swe/problems/dam.py
@@ -1,6 +1,6 @@
 import sys
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/swe/problems/kh.py
+++ b/pyro/swe/problems/kh.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/swe/problems/kh.py
+++ b/pyro/swe/problems/kh.py
@@ -74,4 +74,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/swe/problems/logo.py
+++ b/pyro/swe/problems/logo.py
@@ -3,7 +3,7 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/swe/problems/quad.py
+++ b/pyro/swe/problems/quad.py
@@ -2,7 +2,7 @@ import sys
 
 import numpy as np
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 from pyro.util import msg
 
 

--- a/pyro/swe/problems/quad.py
+++ b/pyro/swe/problems/quad.py
@@ -87,4 +87,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/swe/problems/test.py
+++ b/pyro/swe/problems/test.py
@@ -25,4 +25,3 @@ def init_data(my_data, rp):
 
 def finalize():
     """ print out any information to the user at the end of the run """
-    pass

--- a/pyro/swe/problems/test.py
+++ b/pyro/swe/problems/test.py
@@ -1,6 +1,6 @@
 import sys
 
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 
 
 def init_data(my_data, rp):

--- a/pyro/swe/simulation.py
+++ b/pyro/swe/simulation.py
@@ -5,11 +5,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pyro.mesh.boundary as bnd
-import pyro.particles.particles as particles
-import pyro.swe.derives as derives
 import pyro.swe.unsplit_fluxes as flx
-import pyro.util.plot_tools as plot_tools
+from pyro.particles import particles
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
+from pyro.swe import derives
+from pyro.util import plot_tools
 
 
 class Variables:

--- a/pyro/swe/unsplit_fluxes.py
+++ b/pyro/swe/unsplit_fluxes.py
@@ -123,9 +123,9 @@ Updating U_{i,j}:
 """
 
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.reconstruction as reconstruction
 import pyro.swe as comp
 import pyro.swe.interface as ifc
+from pyro.mesh import reconstruction
 from pyro.util import msg
 
 

--- a/pyro/test.py
+++ b/pyro/test.py
@@ -6,11 +6,9 @@ import datetime
 import os
 import sys
 
-import examples.multigrid.mg_test_general_inhomogeneous as mg_test_general_inhomogeneous
-import examples.multigrid.mg_test_simple as mg_test_simple
-import examples.multigrid.mg_test_vc_dirichlet as mg_test_vc_dirichlet
-import examples.multigrid.mg_test_vc_periodic as mg_test_vc_periodic
 import pyro.pyro_sim as pyro
+from examples.multigrid import (mg_test_general_inhomogeneous, mg_test_simple,
+                                mg_test_vc_dirichlet, mg_test_vc_periodic)
 
 
 class PyroTest:

--- a/pyro/util/io_pyro.py
+++ b/pyro/util/io_pyro.py
@@ -16,12 +16,12 @@ def read_bcs(f):
         gb = f["BC"]
     except KeyError:
         return None
-    else:
-        BCs = {}
-        for name in gb:
-            BCs[name] = gb[name]
 
-        return BCs
+    BCs = {}
+    for name in gb:
+        BCs[name] = gb[name]
+
+    return BCs
 
 
 def read(filename):

--- a/pyro/util/io_pyro.py
+++ b/pyro/util/io_pyro.py
@@ -6,8 +6,8 @@ import importlib
 import h5py
 
 import pyro.mesh.boundary as bnd
-import pyro.particles.particles as particles
 from pyro.mesh.patch import CellCenterData2d, Grid2d
+from pyro.particles import particles
 
 
 def read_bcs(f):

--- a/pyro/util/msg.py
+++ b/pyro/util/msg.py
@@ -27,9 +27,7 @@ def fail(string):
     traceback.print_stack()
     # only exit if we are not running in interactive mode.  sys.ps1 is
     # only defined in interactive mode.
-    if hasattr(sys, 'ps1'):
-        return
-    else:
+    if not hasattr(sys, 'ps1'):
         sys.exit(1)
 
 

--- a/pyro/util/runparams.py
+++ b/pyro/util/runparams.py
@@ -61,8 +61,7 @@ def is_int(string):
         int(string)
     except ValueError:
         return False
-    else:
-        return True
+    return True
 
 
 def is_float(string):
@@ -71,17 +70,15 @@ def is_float(string):
         float(string)
     except ValueError:
         return False
-    else:
-        return True
+    return True
 
 
 def _get_val(value):
     if is_int(value):
         return int(value)
-    elif is_float(value):
+    if is_float(value):
         return float(value)
-    else:
-        return value.strip()
+    return value.strip()
 
 
 class RuntimeParameters:
@@ -212,8 +209,7 @@ class RuntimeParameters:
 
         if key in self.params.keys():
             return self.params[key]
-        else:
-            raise KeyError(f"ERROR: runtime parameter {key} not found")
+        raise KeyError(f"ERROR: runtime parameter {key} not found")
 
     def print_unused_params(self):
         """


### PR DESCRIPTION
This PR is a bunch of minor style fixes suggested by pylint. It resolves all instances of:
* `superfluous-parens`
* `no-else-break`, `no-else-continue`, `no-else-raise`, `no-else-return`
* `use-symbolic-message-instead`
* `trailing-whitespace`
* `consider-using-from-import`
* `unnecessary-pass` (I'm on the fence about this one)
* `attribute-defined-outside-init`