### PR TITLE
Fix more pylint warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ disable = [
   "missing-class-docstring",
   "missing-function-docstring",
   "missing-module-docstring",
+  "pointless-string-statement",
 ]
 enable = [
   "useless-suppression",

--- a/pyro/advection/simulation.py
+++ b/pyro/advection/simulation.py
@@ -106,7 +106,7 @@ class Simulation(NullSimulation):
 
         myg = self.cc_data.grid
 
-        _, axes, cbar_title = plot_tools.setup_axes(myg, 1)
+        _, axes, _ = plot_tools.setup_axes(myg, 1)
 
         # plot density
         ax = axes[0]

--- a/pyro/advection_nonuniform/simulation.py
+++ b/pyro/advection_nonuniform/simulation.py
@@ -131,7 +131,7 @@ class Simulation(NullSimulation):
 
         myg = self.cc_data.grid
 
-        _, axes, cbar_title = plot_tools.setup_axes(myg, 1)
+        _, axes, _ = plot_tools.setup_axes(myg, 1)
 
         # plot density
         ax = axes[0]

--- a/pyro/analysis/convergence.py
+++ b/pyro/analysis/convergence.py
@@ -27,7 +27,7 @@ def compare(fine, coarse):
 
 if __name__ == "__main__":
 
-    if not len(sys.argv) == 3:
+    if len(sys.argv) != 3:
         print(usage)
         sys.exit(2)
 

--- a/pyro/analysis/dam_compare.py
+++ b/pyro/analysis/dam_compare.py
@@ -24,7 +24,7 @@ def abort(string):
     sys.exit(2)
 
 
-if not len(sys.argv) == 2:
+if len(sys.argv) != 2:
     print(usage)
     sys.exit(2)
 

--- a/pyro/analysis/gauss_diffusion_compare.py
+++ b/pyro/analysis/gauss_diffusion_compare.py
@@ -88,7 +88,7 @@ def process(file):
     # now bin the associated data
     phi_bin = np.zeros(len(ncount)-1, dtype=np.float64)
 
-    for n in range(len(ncount)):
+    for n in range(1, len(ncount)):
 
         # remember that there are no whichbin == 0, since that
         # corresponds to the left edge.  So we want whichbin == 1 to
@@ -106,7 +106,7 @@ def process(file):
 
 if __name__ == "__main__":
 
-    if not len(sys.argv) >= 2:
+    if len(sys.argv) < 2:
         print(usage)
         sys.exit(2)
 

--- a/pyro/analysis/incomp_converge_error.py
+++ b/pyro/analysis/incomp_converge_error.py
@@ -16,7 +16,7 @@ usage = """
 """
 
 
-if not len(sys.argv) == 2:
+if len(sys.argv) != 2:
     print(usage)
     sys.exit(2)
 

--- a/pyro/analysis/sedov_compare.py
+++ b/pyro/analysis/sedov_compare.py
@@ -100,7 +100,7 @@ rho_bin = np.zeros(len(ncount)-1, dtype=np.float64)
 u_bin = np.zeros(len(ncount)-1, dtype=np.float64)
 p_bin = np.zeros(len(ncount)-1, dtype=np.float64)
 
-for n in range(len(ncount)):
+for n in range(1, len(ncount)):
 
     # remember that there are no whichbin == 0, since that corresponds
     # to the left edge.  So we want whichbin == 1 to correspond to the

--- a/pyro/analysis/smooth_error.py
+++ b/pyro/analysis/smooth_error.py
@@ -16,7 +16,7 @@ usage = """
       usage: ./smooth_error.py file
 """
 
-if not len(sys.argv) == 2:
+if len(sys.argv) != 2:
     print(usage)
     sys.exit(2)
 

--- a/pyro/analysis/sod_compare.py
+++ b/pyro/analysis/sod_compare.py
@@ -21,7 +21,7 @@ def abort(string):
     sys.exit(2)
 
 
-if not len(sys.argv) == 2:
+if len(sys.argv) != 2:
     print(usage)
     sys.exit(2)
 

--- a/pyro/compressible_react/simulation.py
+++ b/pyro/compressible_react/simulation.py
@@ -92,7 +92,7 @@ class Simulation(compressible.Simulation):
         fields = [rho, magvel, p, e, X]
         field_names = [r"$\rho$", r"U", "p", "e", r"$X_\mathrm{fuel}$"]
 
-        f, axes, cbar_title = plot_tools.setup_axes(myg, len(fields))
+        _, axes, cbar_title = plot_tools.setup_axes(myg, len(fields))
 
         for n, ax in enumerate(axes):
             v = fields[n]

--- a/pyro/compressible_sr/c2p.py
+++ b/pyro/compressible_sr/c2p.py
@@ -58,7 +58,7 @@ def brentq(x1, b, U, gamma, idens, ixmom, iymom, iener,
 
     mflag = True
 
-    for i in range(ITMAX):
+    for _ in range(ITMAX):
         if fa != fc and fb != fc:
             s = a*fb*fc / ((fa-fb) * (fa-fc)) + b*fa*fc / ((fb-fa)*(fb-fc)) + \
                 c*fa*fb / ((fc-fa)*(fc-fb))

--- a/pyro/incompressible/incomp_interface.py
+++ b/pyro/incompressible/incomp_interface.py
@@ -36,6 +36,7 @@ def mac_vels(ng, dx, dy, dt,
 
     # get the full u and v left and right states (including transverse
     # terms) on both the x- and y-interfaces
+    # pylint: disable-next=unused-variable
     u_xl, u_xr, u_yl, u_yr, v_xl, v_xr, v_yl, v_yr = get_interface_states(ng, dx, dy, dt,
                                                                           u, v,
                                                                           ldelta_ux, ldelta_vx,

--- a/pyro/incompressible/simulation.py
+++ b/pyro/incompressible/simulation.py
@@ -422,7 +422,7 @@ class Simulation(NullSimulation):
             0.5*(u.ip(1) - u.ip(-1))/myg.dx + \
             0.5*(v.jp(1) - v.jp(-1))/myg.dy
 
-        fig, axes = plt.subplots(nrows=2, ncols=2, num=1)
+        _, axes = plt.subplots(nrows=2, ncols=2, num=1)
         plt.subplots_adjust(hspace=0.25)
 
         fields = [u, v, vort, divU]

--- a/pyro/lm_atm/LM_atm_interface.py
+++ b/pyro/lm_atm/LM_atm_interface.py
@@ -240,6 +240,7 @@ def mac_vels(ng, dx, dy, dt,
 
     # get the full u and v left and right states (including transverse
     # terms) on both the x- and y-interfaces
+    # pylint: disable-next=unused-variable
     u_xl, u_xr, u_yl, u_yr, v_xl, v_xr, v_yl, v_yr = get_interface_states(ng, dx, dy, dt,
                                                                           u, v,
                                                                           ldelta_ux, ldelta_vx,

--- a/pyro/lm_atm/simulation.py
+++ b/pyro/lm_atm/simulation.py
@@ -640,16 +640,14 @@ class Simulation(NullSimulation):
 
         vort.v()[:, :] = dv - du
 
-        fig, axes = plt.subplots(nrows=2, ncols=2, num=1)
+        _, axes = plt.subplots(nrows=2, ncols=2, num=1)
         plt.subplots_adjust(hspace=0.25)
 
         fields = [rho, magvel, vort, rhoprime]
         field_names = [r"$\rho$", r"|U|", r"$\nabla \times U$", r"$\rho'$"]
 
-        for n in range(len(fields)):
+        for n, f in enumerate(fields):
             ax = axes.flat[n]
-
-            f = fields[n]
 
             img = ax.imshow(np.transpose(f.v()),
                             interpolation="nearest", origin="lower",
@@ -676,8 +674,8 @@ class Simulation(NullSimulation):
 
         gb = f.create_group("base state")
 
-        for key in self.base:
-            gb.create_dataset(key, data=self.base[key].d)
+        for name, state in self.base.items():
+            gb.create_dataset(name, data=state.d)
 
     def read_extras(self, f):
         """

--- a/pyro/multigrid/MG.py
+++ b/pyro/multigrid/MG.py
@@ -568,7 +568,7 @@ class CellCenterMG2d:
         ycoeff = self.beta/myg.dy**2
 
         # do red-black G-S
-        for i in range(nsmooth):
+        for _ in range(nsmooth):
 
             # do the red black updating in four decoupled groups
             #

--- a/pyro/multigrid/general_MG.py
+++ b/pyro/multigrid/general_MG.py
@@ -140,7 +140,7 @@ class GeneralMG2d(MG.CellCenterMG2d):
         beta_y = self.beta_edge[level].y
 
         # do red-black G-S
-        for i in range(nsmooth):
+        for _ in range(nsmooth):
 
             # do the red black updating in four decoupled groups
             #

--- a/pyro/multigrid/variable_coeff_MG.py
+++ b/pyro/multigrid/variable_coeff_MG.py
@@ -129,7 +129,7 @@ class VarCoeffCCMG2d(MG.CellCenterMG2d):
         # print( "min/max eta_y: {}, {}".format(np.min(eta_y), np.max(eta_y)))
 
         # do red-black G-S
-        for i in range(nsmooth):
+        for _ in range(nsmooth):
 
             # do the red black updating in four decoupled groups
             #

--- a/pyro/particles/particles.py
+++ b/pyro/particles/particles.py
@@ -123,7 +123,7 @@ class Particles:
 
         self.sim_data = sim_data
         self.bc = bc
-        self.particles = dict()
+        self.particles = {}
 
         if n_particles <= 0:
             msg.fail("ERROR: n_particles = %s <= 0" % (n_particles))
@@ -237,7 +237,7 @@ class Particles:
         elif v is None:
             v = self.sim_data.get_var("y-velocity")
 
-        for k, p in self.particles.items():
+        for p in self.particles.values():
 
             # save old position and predict location at dt/2
             initial_position = p.pos()
@@ -266,7 +266,7 @@ class Particles:
         boundaries.
         """
         old_particles = self.particles.copy()
-        self.particles = dict()
+        self.particles = {}
 
         myg = self.sim_data.grid
 

--- a/pyro/simulation_null.py
+++ b/pyro/simulation_null.py
@@ -85,7 +85,7 @@ def bc_setup(rp):
     return bc, bc_xodd, bc_yodd
 
 
-class NullSimulation(object):
+class NullSimulation:
 
     def __init__(self, solver_name, problem_name, rp, timers=None, data_class=patch.CellCenterData2d):
         """

--- a/pyro/test.py
+++ b/pyro/test.py
@@ -110,7 +110,7 @@ def do_tests(out_file,
 
         f.write(f"\n{failed} test(s) failed\n")
 
-        if not f == sys.stdout:
+        if f != sys.stdout:
             f.close()
 
     return failed

--- a/pyro/util/io_pyro.py
+++ b/pyro/util/io_pyro.py
@@ -63,8 +63,8 @@ def read(filename):
             else:
                 bc_solver = solver_name
             bcmod = importlib.import_module(f"pyro.{bc_solver}.BC")
-            for name in custom_bcs:
-                bnd.define_bc(name, bcmod.user, is_solid=custom_bcs[name])
+            for name, is_solid in custom_bcs.items():
+                bnd.define_bc(name, bcmod.user, is_solid=is_solid)
 
         # read in the variable info -- start by getting the names
         gs = f["state"]

--- a/pyro/util/runparams.py
+++ b/pyro/util/runparams.py
@@ -145,7 +145,7 @@ class RuntimeParameters:
                 # if we have no_new = 1, then we only want to override existing
                 # key/values
                 if no_new:
-                    if key not in self.params.keys():
+                    if key not in self.params:
                         msg.warning("warning, key: %s not defined" % (key))
                         continue
 
@@ -186,7 +186,7 @@ class RuntimeParameters:
             key, value = item.split("=")
 
             # we only want to override existing keys/values
-            if key not in self.params.keys():
+            if key not in self.params:
                 msg.warning("warning, key: %s not defined" % (key))
                 continue
 
@@ -199,7 +199,7 @@ class RuntimeParameters:
         input key
         """
 
-        if self.params == {}:
+        if not self.params:
             msg.warning("WARNING: runtime parameters not yet initialized")
             self.load_params("_defaults")
 
@@ -207,7 +207,7 @@ class RuntimeParameters:
         if key not in self.used_params:
             self.used_params.append(key)
 
-        if key in self.params.keys():
+        if key in self.params:
             return self.params[key]
         raise KeyError(f"ERROR: runtime parameter {key} not found")
 


### PR DESCRIPTION
Fix a spurious divide-by-zero error in sedov_compare.py and gauss_diffusion_compare.py that pylint found. Most of the other fixes are for `unused-variable`, plus some instances of `consider-using-enumerate`, `consider-using-dict-items`, `consider-iterating-dictionary`, `use-dict-literal`, `useless-object-inheritance`, and `unneeded-not`.

Also disable `pointless-string-statement`, since these are used for block comments in a couple places.