### PR TITLE
Clean up pylint warnings in unit tests and update flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,20 @@
 [flake8]
 max-line-length = 132
-ignore = E126, E127, E128, E129, E226, E241, E265, E741, F401, F403, F841, W504, W291
+
+# E126: continuation line over-indented for hanging indent
+# E127: continuation line over-indented for visual indent
+# E128: continuation line under-indented for visual indent
+# E129: visually indented line with same indent as next logical line
+# E226: missing whitespace around arithmetic operator
+# E241: multiple spaces after ','
+# E265: block comment should start with '# '
+# E741: do not use variables named 'I', 'O', or 'l'
+# F403: 'from module import *' used; unable to detect undefined names
+# F841: local variable assigned to but never used
+# W504: line break after binary operator
+ignore = E126, E127, E128, E129, E226, E241, E265, E741, F403, F841, W504
+
+# F401: module imported but unused
+per-file-ignores = __init__.py:F401
+
 exclude = docs/,lm_combustion,radhydro

--- a/.flake8
+++ b/.flake8
@@ -17,4 +17,4 @@ ignore = E126, E127, E128, E129, E226, E241, E265, E741, F403, F841, W504
 # F401: module imported but unused
 per-file-ignores = __init__.py:F401
 
-exclude = docs/,lm_combustion,radhydro
+exclude = docs/

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -41,5 +41,5 @@ jobs:
         run: pip install .
 
       - name: Validate
-        run: pylint --errors-only pyro pyro/analysis
+        run: pylint --errors-only pyro pyro/analysis pyro/**/tests/*.py
 

--- a/logo/logo.py
+++ b/logo/logo.py
@@ -8,7 +8,7 @@ logo_text = """
  XXX   XXX X     XX  
  X       X           
  X      X            
-"""
+"""  # noqa
 
 
 class LogoGrid:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ defining-attr-methods = [
   "__post_init__",
   "initialize",
   "__array_finalize__",
+  "setup_class", "setup_method",  # for tests
 ]
 
 [tool.pylint.FORMAT]

--- a/pyro/advection/tests/test_advection.py
+++ b/pyro/advection/tests/test_advection.py
@@ -2,16 +2,14 @@ import pyro.advection.simulation as sn
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/advection_nonuniform/tests/test_advection_nonuniform.py
+++ b/pyro/advection_nonuniform/tests/test_advection_nonuniform.py
@@ -2,16 +2,14 @@ import pyro.advection_nonuniform.simulation as sn
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/compressible/tests/test_compressible.py
+++ b/pyro/compressible/tests/test_compressible.py
@@ -6,16 +6,14 @@ import pyro.compressible.simulation as sn
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/compressible/tests/test_eos.py
+++ b/pyro/compressible/tests/test_eos.py
@@ -1,4 +1,4 @@
-import pyro.compressible.eos as eos
+from pyro.compressible import eos
 
 
 def test_eos_consistency():

--- a/pyro/compressible_rk/tests/test_compressible_rk.py
+++ b/pyro/compressible_rk/tests/test_compressible_rk.py
@@ -2,16 +2,14 @@ import pyro.compressible_rk.simulation as sn
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/compressible_sr/tests/test_compressible_sr.py
+++ b/pyro/compressible_sr/tests/test_compressible_sr.py
@@ -7,16 +7,14 @@ import pyro.compressible_sr.unsplit_fluxes as flx
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/compressible_sr/tests/test_eos_sr.py
+++ b/pyro/compressible_sr/tests/test_eos_sr.py
@@ -1,4 +1,4 @@
-import pyro.compressible_sr.eos as eos
+from pyro.compressible_sr import eos
 
 
 def test_eos_consistency():

--- a/pyro/diffusion/tests/test_diffusion.py
+++ b/pyro/diffusion/tests/test_diffusion.py
@@ -2,17 +2,15 @@ import pyro.diffusion.simulation as sn
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
 
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/incompressible/tests/convergence_errors.py
+++ b/pyro/incompressible/tests/convergence_errors.py
@@ -10,14 +10,13 @@ def create_file(filename="convergence_errors.txt"):
     # Parse all converge*.h5 outputs
     # store the last file at each resolution
     fnames = glob.glob("converge*.h5")
-    res = set([f.split("_")[1] for f in fnames])
-    res = list(res)
-    res.sort(key=int)
+    res = {f.split("_")[1] for f in fnames}
+    res = sorted(res, key=int)
 
     simfiles = []
     for r in res:
         fnames = glob.glob(f"converge_{r}_*.h5")
-        last = max([int(f.split("_")[-1].split(".")[0]) for f in fnames])
+        last = max(int(f.split("_")[-1].split(".")[0]) for f in fnames)
         simfiles.append(f"converge_{r}_{last:04d}.h5")
 
     # Create the file

--- a/pyro/mesh/tests/test_array_indexer.py
+++ b/pyro/mesh/tests/test_array_indexer.py
@@ -2,11 +2,12 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import pyro.mesh.array_indexer as ai
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 
 
 # utilities
 def test_buf_split():
+    # pylint: disable=protected-access
     assert_array_equal(ai._buf_split(2), [2, 2, 2, 2])
     assert_array_equal(ai._buf_split((2, 3)), [2, 3, 2, 3])
 

--- a/pyro/mesh/tests/test_io.py
+++ b/pyro/mesh/tests/test_io.py
@@ -2,8 +2,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import pyro.mesh.boundary as bnd
-import pyro.mesh.patch as patch
 import pyro.util.io_pyro as io
+from pyro.mesh import patch
 
 
 def test_write_read():

--- a/pyro/mesh/tests/test_patch.py
+++ b/pyro/mesh/tests/test_patch.py
@@ -3,20 +3,18 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import pyro.mesh.boundary as bnd
-import pyro.mesh.patch as patch
+from pyro.mesh import patch
 
 
 # Grid2d tests
-class TestGrid2d(object):
+class TestGrid2d:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """
@@ -71,16 +69,14 @@ class TestGrid2d(object):
 
 
 # CellCenterData2d tests
-class TestCellCenterData2d(object):
+class TestCellCenterData2d:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/multigrid/tests/test_multigrid_comps.py
+++ b/pyro/multigrid/tests/test_multigrid_comps.py
@@ -3,9 +3,8 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-import pyro.mesh.patch as patch
-import pyro.multigrid.edge_coeffs as edge_coeffs
-import pyro.multigrid.MG as MG
+from pyro.mesh import patch
+from pyro.multigrid import MG, edge_coeffs
 
 
 # utilities

--- a/pyro/particles/tests/test_particles.py
+++ b/pyro/particles/tests/test_particles.py
@@ -1,8 +1,8 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-import pyro.mesh.patch as patch
-import pyro.particles.particles as particles
+from pyro.mesh import patch
+from pyro.particles import particles
 from pyro.simulation_null import NullSimulation, bc_setup, grid_setup
 from pyro.util import runparams
 
@@ -14,7 +14,7 @@ def test_particle():
 
     n_particles = 5
 
-    for n in range(n_particles):
+    for _ in range(n_particles):
         x, y = np.random.rand(2)
         p = particles.Particle(x, y)
 
@@ -47,7 +47,6 @@ def setup_test(n_particles=50, extra_rp_params=None):
     rp.params["mesh.ymin"] = 0
     rp.params["mesh.ymax"] = 1
     rp.params["particles.do_particles"] = 1
-    n_particles = n_particles
 
     if extra_rp_params is not None:
         for param, value in extra_rp_params.items():
@@ -77,7 +76,7 @@ def test_particles_random_gen():
     np.random.seed(3287469)
 
     ps = particles.Particles(myd, bc, n_particles, "random")
-    positions = set([(p.x, p.y) for p in ps.particles.values()])
+    positions = {(p.x, p.y) for p in ps.particles.values()}
 
     assert len(ps.particles) == n_particles, "There should be {} particles".format(n_particles)
 
@@ -85,7 +84,8 @@ def test_particles_random_gen():
     np.random.seed(3287469)
 
     correct_positions = np.random.rand(n_particles, 2)
-    correct_positions = set([(x, y) for (x, y) in correct_positions])
+    # pylint: disable-next=unnecessary-comprehension  # needed to convert ndarray to tuples
+    correct_positions = {(x, y) for (x, y) in correct_positions}
 
     assert positions == correct_positions, "sets are not the same"
 
@@ -101,12 +101,12 @@ def test_particles_grid_gen():
 
     assert len(ps.particles) == 49, "There should be 49 particles"
 
-    positions = set([(p.x, p.y) for p in ps.particles.values()])
+    positions = {(p.x, p.y) for p in ps.particles.values()}
 
     xs, step = np.linspace(0, 1, num=7, endpoint=False, retstep=True)
     xs += 0.5 * step
 
-    correct_positions = set([(x, y) for x in xs for y in xs])
+    correct_positions = {(x, y) for x in xs for y in xs}
 
     assert positions == correct_positions, "sets are not the same"
 
@@ -124,9 +124,10 @@ def test_particles_array_gen():
     ps = particles.Particles(myd, bc, n_particles,
                              "array", pos_array=init_positions)
 
-    positions = set([(p.x, p.y) for p in ps.particles.values()])
+    positions = {(p.x, p.y) for p in ps.particles.values()}
 
-    correct_positions = set([(x, y) for (x, y) in init_positions])
+    # pylint: disable-next=unnecessary-comprehension  # needed to convert ndarray to tuples
+    correct_positions = {(x, y) for (x, y) in init_positions}
 
     assert positions == correct_positions, "sets are not the same"
 
@@ -153,12 +154,12 @@ def test_particles_advect():
 
     ps.update_particles(1, u, v)
 
-    positions = set([(p.x, p.y) for p in ps.particles.values()])
+    positions = {(p.x, p.y) for p in ps.particles.values()}
 
     xs, step = np.linspace(0, 1, num=7, endpoint=False, retstep=True)
     xs += 0.5 * step
 
-    correct_positions = set([(x, y) for x in xs for y in xs])
+    correct_positions = {(x, y) for x in xs for y in xs}
 
     assert positions == correct_positions, "sets are not the same"
 
@@ -167,9 +168,9 @@ def test_particles_advect():
 
     ps.update_particles(0.1, u, v)
 
-    positions = set([(p.x, p.y) for p in ps.particles.values()])
+    positions = {(p.x, p.y) for p in ps.particles.values()}
 
-    correct_positions = set([((x+0.1) % 1, y) for x in xs for y in xs])
+    correct_positions = {((x+0.1) % 1, y) for x in xs for y in xs}
 
     assert positions == correct_positions, "sets are not the same"
 
@@ -180,9 +181,9 @@ def test_particles_advect():
     ps = particles.Particles(myd, bc, n_particles, "grid")
     ps.update_particles(0.1, u, v)
 
-    positions = set([(p.x, p.y) for p in ps.particles.values()])
+    positions = {(p.x, p.y) for p in ps.particles.values()}
 
-    correct_positions = set([(x, (y+0.1) % 1) for x in xs for y in xs])
+    correct_positions = {(x, (y+0.1) % 1) for x in xs for y in xs}
 
     assert positions == correct_positions, "sets are not the same"
 
@@ -192,9 +193,9 @@ def test_particles_advect():
     ps = particles.Particles(myd, bc, n_particles, "grid")
     ps.update_particles(0.1, u, v)
 
-    positions = set([(p.x, p.y) for p in ps.particles.values()])
+    positions = {(p.x, p.y) for p in ps.particles.values()}
 
-    correct_positions = set([((x+0.1) % 1, (y+0.1) % 1) for x in xs for y in xs])
+    correct_positions = {((x+0.1) % 1, (y+0.1) % 1) for x in xs for y in xs}
 
     assert positions == correct_positions, "sets are not the same"
 

--- a/pyro/swe/tests/test_swe.py
+++ b/pyro/swe/tests/test_swe.py
@@ -5,16 +5,14 @@ import pyro.swe.simulation as sn
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """

--- a/pyro/tests/test_pyro.py
+++ b/pyro/tests/test_pyro.py
@@ -4,25 +4,21 @@ from numpy.testing import assert_array_equal
 from pyro.pyro_sim import Pyro
 
 
-class TestSimulation(object):
+class TestSimulation:
 
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """
-        pass
 
     def teardown_method(self):
         """ this is run after each test """
-        pass
 
     def test_pyro_class(self):
         """

--- a/pyro/tests/test_simulation.py
+++ b/pyro/tests/test_simulation.py
@@ -1,20 +1,18 @@
 import pyro.mesh.boundary as bnd
-import pyro.mesh.patch as patch
 import pyro.simulation_null as sn
+from pyro.mesh import patch
 from pyro.util import runparams
 
 
-class TestSimulation(object):
+class TestSimulation:
 
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """
@@ -65,7 +63,7 @@ class TestSimulation(object):
 
         # now test what happens if we go over tmax
         self.sim.cc_data.t = 0.75
-        self.dt = 0.5
+        self.sim.dt = 0.5
         self.sim.compute_timestep()
         assert self.sim.dt == 0.25
 

--- a/pyro/util/tests/test_runparams.py
+++ b/pyro/util/tests/test_runparams.py
@@ -18,21 +18,20 @@ def test_is_float():
 
 
 def test_get_val():
+    # pylint: disable=protected-access
     assert rp._get_val("1.5") == 1.5
 
 
 # test the runtime parameter class
-class TestRunParams(object):
+class TestRunParams:
 
     @classmethod
     def setup_class(cls):
         """ this is run once for each class before any tests """
-        pass
 
     @classmethod
     def teardown_class(cls):
         """ this is run once for each class after all tests """
-        pass
 
     def setup_method(self):
         """ this is run before each test """


### PR DESCRIPTION
Adds short descriptions for all the ignored flake8 error codes.
W291 (trailing whitespace) is no longer ignored and F401 (module imported but unused) is only ignored for `__init__.py` files.