### PR TITLE
Skip checking the output of `help()` in a notebook

### DIFF
--- a/pyro/mesh/mesh-examples.ipynb
+++ b/pyro/mesh/mesh-examples.ipynb
@@ -80,7 +80,11 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",


### PR DESCRIPTION
Python 3.11.7 and 3.12.1 removed the `(if defined)` notice on `__dict__` and `__weakref__`.