### PR TITLE
Simplify pytest usage

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,4 +36,4 @@ jobs:
         run: pip install .
 
       - name: Run tests with pytest
-        run: pytest -v --cov=pyro --nbval --ignore=docs --ignore=./pyro/multigrid/derive_analytic_solutions.ipynb --ignore=examples/mesh --ignore=examples/multigrid --ignore=presentations
+        run: pytest -v --cov=pyro --nbval --color=yes

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ with their data.
   Unit tests are controlled by pytest and can be run simply via
 
   ```
-  pytest pyro
+  pytest
   ```
 
 ## Acknowledgements

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -13,7 +13,7 @@ pyro implements unit tests using ``pytest``.  These can be run via:
 
 .. prompt:: bash
 
-   pytest -v --nbval pyro
+   pytest -v --nbval
 
 
 Regression tests

--- a/examples/mesh/experiments/test_indexer.py
+++ b/examples/mesh/experiments/test_indexer.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-import mesh.patch as patch
+from pyro.mesh import patch
 
 myg = patch.Grid2d(8, 8, ng=2)
 a = myg.scratch_array()

--- a/examples/mesh/experiments/test_mask.py
+++ b/examples/mesh/experiments/test_mask.py
@@ -4,8 +4,8 @@ import time
 
 import numpy as np
 
-import mesh.boundary as bnd
-from mesh import patch
+import pyro.mesh.boundary as bnd
+from pyro.mesh import patch
 
 
 class Mask(object):

--- a/examples/mesh/experiments/test_subclass.py
+++ b/examples/mesh/experiments/test_subclass.py
@@ -19,9 +19,9 @@
 
 import numpy as np
 
-import mesh.array_indexer as ai
-import mesh.patch as patch
-from util import msg
+import pyro.mesh.array_indexer as ai
+from pyro.mesh import patch
+from pyro.util import msg
 
 _buf_split = ai._buf_split
 
@@ -121,7 +121,7 @@ class ArrayIndexer(np.ndarray):
         a different color, to make things stand out
         """
 
-        if self.dtype == np.int:
+        if self.dtype == int:
             fmt = "%4d"
         elif self.dtype == np.float64:
             fmt = "%10.5g"

--- a/presentations/pyro_intro.ipynb
+++ b/presentations/pyro_intro.ipynb
@@ -184,8 +184,8 @@
    },
    "outputs": [],
    "source": [
-    "import mesh.patch as patch\n",
-    "import mesh.boundary as bnd\n",
+    "import pyro.mesh.patch as patch\n",
+    "import pyro.mesh.boundary as bnd\n",
     "import numpy as np"
    ]
   },
@@ -344,7 +344,10 @@
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": [
+     "nbval-ignore-output"
+    ]
    },
    "outputs": [
     {
@@ -393,7 +396,7 @@
     }
    ],
    "source": [
-    "from pyro import Pyro\n",
+    "from pyro.pyro_sim import Pyro\n",
     "pyro_sim = Pyro(\"advection\")\n",
     "pyro_sim.initialize_problem(\"tophat\", \"inputs.tophat\",\n",
     "                            other_commands=[\"mesh.nx=8\", \"mesh.ny=8\",\n",
@@ -475,21 +478,10 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/alice/Documents/pyro2/advection/simulation.py:121: MatplotlibDeprecationWarning: Since 3.2, mpl_toolkits's own colorbar implementation is deprecated; it will be removed two minor releases later.  Set the 'mpl_toolkits.legacy_colorbar' rcParam to False to use Matplotlib's default colorbar implementation and suppress this deprecation warning.\n",
-      "  cb = axes.cbar_axes[0].colorbar(img)\n",
-      "/home/alice/anaconda3/lib/python3.7/site-packages/mpl_toolkits/axes_grid1/axes_grid.py:51: MatplotlibDeprecationWarning: \n",
-      "The mpl_toolkits.axes_grid1.colorbar module was deprecated in Matplotlib 3.2 and will be removed two minor releases later. Use matplotlib.colorbar instead.\n",
-      "  from .colorbar import Colorbar\n"
-     ]
-    },
-    {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEaCAYAAADNBJaSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAaEUlEQVR4nO3df7RlZX3f8fdnZpiAiIAMIBlAJjoJIVYsjmAbbVCLAk2KGluRxF81nZKIpkttYWW12qVpVtA/4nKJTkbCQtMq/kIc7YSRxBq0iBmwiAyITFFhHO2sERFEcebe++kfe1965txz79n3zrn7PGfzebH2uufs/ez9fO9wz/c+99nP82zZJiIiyrJi3AFERMRcSc4REQVKco6IKFCSc0REgZKcIyIKlOQcEVGgJOeImCiSrpb0p8t4/R2Szl6u6ze1atwBRESUxPZvzL6W9F+Ap9v+/bbjSMs5IqJASc4RUTRJ/1jS1yU9LOnjwKE9x35b0m2SHpR0k6Rn9hz7rqS3Sbpd0k8kfVzSofWxNZI+X5/3gKQvS1rRc94/l3Qu8CfAKyX9VNI3JP0rSbf2xfdWSdeN+vtOco6IYklaDVwH/DXwZOCTwO/Wx84ArgL+HXAM8JfAFkm/1HOJfw2cC6wDngm8rt7/VmAXcCxwPFUSPmAtC9vXA38GfNz2E22fDmwB1kn69Z6iv1/HN1JJzhFRsucChwDvtb3f9qeA7fWxfwv8pe2v2Z62/WHgF/U5s95ne7ftB4DPAc+q9+8HTgCeWl/3y26w0JDtXwAfp0rISPoN4BTg8wf7jfZLco6Ikv0y8P2+xPm9+utTgbfWXRMPSnoQOKk+Z9YPe17/DHhi/fo9wE7gC5LulXTZImL6MHCRJAGvBj5RJ+2RSnKOiJL9AFhbJ8JZJ9df7wf+q+2jerYn2P7YsIvaftj2W23/CvA7wFskvWhQ0QHn3gzsA54PXMQydGlAknNElO2rwBTwZkmrJL0cOLM+9iHgYklnqXK4pH8h6YhhF61vJD69TvoPAdP11u//AqfM3izs8RHg/cCU7a8s8XtbUJJzRBTL9j7g5VQ38n4MvBK4tj52C1W/8/vrYzv5/zf8hlkP/C3wU6pfAB+w/aUB5T5Zf/2RpK/37P9r4BksU6sZQFlsPyJicSQdBuwBzrB9z3LUkZZzRMTi/SGwfbkSMyQ5DyTpKkl7JN0xz3FJep+knfUA9zPajjEixkPSd4E/phorvWySnAe7mmrg+nzOo+qzWg9sBD7YQkwRUQDbp9h+qu3/vZz1JDkPYPtG4IEFilwAfMSVm4GjJJ3QTnQR8XiQVemWZi3VGMtZu+p9PxhPOBExiKRnNy1r+9bhpdqT5Lw0GrBv4LAXSRupuj5YyapnH77yqOWMK+Jx7eczD7Nv5tHHPp9HPmnFLSccv7LRuZL22j522YJbpCTnpdlFNU101onA7kEFbW8GNgMcuepY/5MjX7b80QF4pp16Igry1Yc+e8D7p59yCP+w7eR5Sh9o5Qn3fG94qfakz3lptgCvqUdtPBf4ie10aUQUxsBMw/9Kk5bzAJI+BpwNrJG0C3gH1cpY2N4EbAXOp5qR9DPg9eOJNCIWZqYn9K/IJOcBbL9qyHEDb2wpnIhYIgNTA5fMKF+Sc0R0ljHTE7pERZJzRHTazOCBVMVLco6IzjIwneQcEVGetJwjIgpjYH/6nCMiymKcbo2IiOIYpiczN2eGYER0VzVDsNnWhKRzJd1dr+U+7xO7JT1H0rSkV/Ts+66kb0q6TdItw+pKyzkiOkxMD1ynbAlXklYCVwDnUK2vs13SFtt3Dih3ObBtwGVeYHtvk/rSco6IzjIw42ZbA2cCO23fWz949hqqtd37vQn4NNUzBpcsyTkiOsvAPlY02hqYbx33x0haC7wM2DRPOF+QdGu9lPCC0q0REZ0248bdGmv6+oI310v+zmqyjvt7gUttT0tziv+m7d2SjgNukPSt+qlLAyU5R0RnVTMEGyfnvbY3LHC8yTruG4Br6sS8Bjhf0pTt62zvBrC9R9JnqLpJkpwj4vHHiOnR9d5uB9ZLWgd8H7gQuOiA+ux1s68lXQ183vZ1kg4HVth+uH79YuCdC1WW5BwRnbaIbo0F2Z6SdAnVKIyVwFW2d0i6uD4+qJ951vHAZ+oW9Srgo7avX6i+JOeI6Cwj9rnZMwQbXc/eSvWwjd59A5Oy7df1vL4XOH0xdSU5R0RnVZNQJnNQWpJzRHTaqCahtC3JOSI6yxbTTss5IqI4M2k5R0SUpRrnnJZzNDGhj2kvyiGrW6tKqw9pra42+dFH261wejxPwDZivyczzU1m1BERDU2PaJxz25KcI6KzRjxDsFVJzhHRaTMZrRERUZbcEIyIKJBR+pwjIkpjk9EaERHlUSahRESUxpDp2xERJcoNwYiIwhiNbLH9tiU5R0RnmdwQjIgokLKec0REaczkzhCczKiXmaRzJd0taaekywYcP1LS5yR9Q9IOSa8fR5wRMdx03XoetpUmLec+klYCVwDnALuA7ZK22L6zp9gbgTtt/46kY4G7Jf132/vGEHJEzMPWxLack5znOhPYWT8tF0nXABcAvcnZwBGqnnP+ROABYKrtQCNiuIxz7o61wP0973cBZ/WVeT+wBdgNHAG80h68ir6kjcBGgENXHD7yYCNiftVi+yvHHcaSTOavlOU1qPPJfe9fAtwG/DLwLOD9kp406GK2N9veYHvDah022kgjYkHVDUE12kqT5DzXLuCknvcnUrWQe70euNaVncB3gFNbii8iFmGaFY220pQX0fhtB9ZLWidpNXAhVRdGr/uAFwFIOh74NeDeVqOMiKFmZwhOYss5fc59bE9JugTYBqwErrK9Q9LF9fFNwLuAqyV9k6ob5FLbe8cWdETMa2ZC26BJzgPY3gps7du3qef1buDFbccVEYtj5wGvERHFMWJqZjJHayQ5R0SnlTj7r4kk54jorNmhdJMoyTkiOizTtyMiipRnCEYzaum3+Mr2Wgs+8fjW6gL44fOOaq2unx/XPzl0+Tx5R3t1Hf2V+1qrC8CPPNJqfY/Va9ifG4IREWXJY6oiIgqVbo2IiMJktEZERKEyWiMiojSFLmrURJJzRHSWgam0nCMiypI+54iIQiU5R0QUJuOcIyIKlXHOERGlcbo1IiKKY2BqJqM1IiKKkj7niIhCOck5IqI8uSEYEVEY54ZgRESJxHRuCEZElCd9zhERhcnaGhERJXLV7zyJkpwjotMmdbTGZPaUR0Q0YKo+5yZbE5LOlXS3pJ2SLhtw/AJJt0u6TdItkp7X9Nx+aTlHRIeJ6ZnRtJwlrQSuAM4BdgHbJW2xfWdPsb8Dtti2pGcCnwBObXjuAdJyjohOG2HL+Uxgp+17be8DrgEuOLAu/9R+rJf7cKrGe6Nz+yU5R0Rn2SNNzmuB+3ve76r3HUDSyyR9C/gfwL9ZzLm9kpwjotNm6oe8DtuANXU/8ey2se9SgzL4nLEgtj9j+1TgpcC7FnNur/Q5t0nAipbuHB93TDv1APe8+kmt1QVw+yvf21pdT1ixurW6Tr3yD1ur6+ivtFbV2C1iKN1e2xsWOL4LOKnn/YnA7vnr9Y2SniZpzWLPhbScI6LDjJiZWdFoa2A7sF7SOkmrgQuBLb0FJD1dkurXZwCrgR81ObdfkvMATYa8SDq7Hi6zQ9Lftx1jRDTjhtvQ69hTwCXANuAu4BO2d0i6WNLFdbHfBe6QdBvV6IxXujLw3IXqS7dGnyZDXiQdBXwAONf2fZKOG0+0EbEgj3ZtDdtbga19+zb1vL4cuLzpuQtJy3muJkNeLgKutX0fgO09LccYEU2NquncsiTnuZoMeflV4GhJX5J0q6TXtBZdRCzKKGcItindGnM1GfKyCng28CLgMOCrkm62/e05F6uG42wEOHTFE0ccakQMk4WPuqPJkJddVMNuHgEekXQjcDowJznb3gxsBjjykGMn9MckYjLZ4AldbH8yo15eTYa8fBZ4vqRVkp4AnEV1BzYiCmM320qTlnMf21OSZoe8rASumh0uUx/fZPsuSdcDtwMzwJW27xhf1BExrwITbxNJzgMMGy5Tv38P8J4244qIxSrzZl8TSc4R0W1pOUdEFGbEk1DalOQcEd2W5BwRUaB0a0REFCjJOSKiMCbdGhERJSpxgkkTSc4R0W0jevp225KcI6LTlJZzRERhCl2ruYkk54joMOWGYEREkdJyjogoUJJzRERhTEZrRESUaFJHa3T6SSiSLpF09LjjiIgxmtCnb3e95fwUYLukrwNXAdvsMc4XMjA93UpVeuTnrdQD4A7/iv/ZzL7W6jpsT3t/fnvf/tbqiqXp8McKbP8nYD3wV8DrgHsk/Zmkp401sIhojdxsK02nkzNA3VL+Yb1NAUcDn5L07rEGFhHtsJpthel0t4akNwOvBfYCVwL/wfZ+SSuAe4D/OM74ImKZmeoRzBOo08kZWAO83Pb3enfanpH022OKKSJaVGKXRROdTs62377AsbvajCUixiTJOSKiQEnOERFlKXUkRhNJzhHRbZm+HRFRnrScIyJKlOQcEVGY9DlHRBQqyTkiokBJzhER5Um3RkREiZKcIyIKkxuCERGFSnKOiCjQhCbnzi+2vxSSzpV0t6Sdki5boNxzJE1LekWb8UVEMyJPQukMSSuBK4DzgNOAV0k6bZ5ylwPb2o0wIhozaKbZVpok57nOBHbavtf2PuAa4IIB5d4EfBrY02ZwEbFIE/r07STnudYC9/e831Xve4yktcDLgE3DLiZpo6RbJN2yz+09ETsiaknOnTFofcH+/3XvBS61PT3sYrY3295ge8NqHTaSACOiuUntc85ojbl2ASf1vD8R2N1XZgNwjSSonlN4vqQp29e1E2JENFZg4m0iyXmu7cB6SeuA7wMXAhf1FrC9bva1pKuBzycxRxTIZd7sayLJuY/tKUmXUI3CWAlcZXuHpIvr40P7mSOiIGk5d4ftrcDWvn0Dk7Lt1zW+8MwMfvQXBxVbU9MP3j+80IicvO0prdUF8I94c2t1tdnqWv+VB9urbP++9uoasxL7k5tIco6IbktyjogoTKHD5JpIco6IzhKDx8ZOgiTniOi0SR2tkUkoEdFtI5whOGxRNEmnSvqqpF9Ielvfse9K+qak2yTdMqyutJwjottG1OfcsyjaOVST1bZL2mL7zp5iDwBvBl46z2VeYHtvk/rSco6I7mo4dbvhcLuhi6LZ3mN7O7D/YENPco6Ibhtdt8bQRdEaRPIFSbdK2jiscLo1IqLTFjEJZU1fX/Bm25t7LzXgnMV0mvym7d2SjgNukPQt2zfOVzjJOSI6bRGjNfba3rDA8SaLos3L9u766x5Jn6HqJpk3OadbIyK6q2mXRrP272OLoklaTbUo2pYmJ0o6XNIRs6+BFwN3LHROWs4R0W0jGq3RZFE0SU8BbgGeBMxI+vdUj7tbA3ymXmZ4FfBR29cvVF+Sc0R01uwDXkdl2KJotn9I1d3R7yHg9MXUleQcEd2WtTUiIgpj0MxkZuck54jotKznHBFRoiTniIjypOUcEVGiJOeIiMI0X9SoOEnOEdFZYnIX209yjohu82Q2nZOcI6LT0q0REVGaPH07IqJM6XOOiChQknNERGlMbghGAxIcckg7dT36aDv1AKuv395aXQCn3nXS8EIj4sMPa60u9vyovboeR3JDMCKiREnOERFlGfVi+21Kco6I7rLT5xwRUaKM1oiIKFC6NSIiSmNgQh9TtWLcAZRI0rmS7pa0U9JlA47/nqTb6+0mSYt6qm5EtMgNt8Kk5dxH0krgCuAcYBewXdIW23f2FPsO8Fu2fyzpPGAzcFb70UbEMOnW6I4zgZ227wWQdA1wAfBYcrZ9U0/5m4ETW40wIpqb0NEa6daYay1wf8/7XfW++bwB+JtljSgilsbVaI0mW2nScp5LA/YN/NUr6QVUyfl5815M2ghsBDhUh48ivohoqJqEMpkt5yTnuXYBvYs3nAjs7i8k6ZnAlcB5tuddFMH2Zqo+aY5cuWYyf0oiJlmBreIm0q0x13ZgvaR1klYDFwJbegtIOhm4Fni17W+PIcaIaEh2o600aTn3sT0l6RJgG7ASuMr2DkkX18c3AW8HjgE+IAlgyvaGccUcEfModJhcE0nOA9jeCmzt27ep5/UfAH/QdlwRsVhGEzoJJck5IrqtwC6LJpKcI6K7XOYwuSaSnCOi29Jyjogo0GTm5iTniOi2EofJNZHkHBHdZWA6yTkioiiizAkmTSQ5R0S3JTlHRBQoyTkiojBmYhc+SnKOiE5Ln3MMJ6FV7fyTrzjiiFbqAWD//vbqAvyTh9qr7KePtFfXhK4B0YjGtQCmYWYym85JzhHRXSZ9zhERRZrMhnOSc0R0W/qcIyJKlOQcEVEYG6Yns18jyTkiui0t54iIAiU5R0QUxkzs+PEk54joMIPT5xwRUZ50a0REFMZktEZERJHSco6IKI0nNjmPa6moiIjlZ6pV6ZpsDUg6V9LdknZKumzAcUl6X338dklnND23X5JzRHSb3WwbQtJK4ArgPOA04FWSTusrdh6wvt42Ah9cxLkHSHKOiG4bUXIGzgR22r7X9j7gGuCCvjIXAB9x5WbgKEknNDz3AOlzjojusvH0dNPSayTd0vN+s+3NPe/XAvf3vN8FnNV3jUFl1jY89wBJzhHRbc1nCO61vWGB4xqwr//i85Vpcu4BkpwjottGN1pjF3BSz/sTgd0Ny6xucO4B0uccEd1lj3K0xnZgvaR1klYDFwJb+spsAV5Tj9p4LvAT2z9oeO4B0nKOiG4bUcvZ9pSkS4BtwErgKts7JF1cH98EbAXOB3YCPwNev9C5C9WX5BwRHbaoG4LDr2ZvpUrAvfs29bw28Mam5y4kyTkiumuClwxNn/MABzMLKCIK45lmW2HScu7TM5PnHKo7r9slbbF9Z0+x3llAZ1HNAlpwzGJEtM+AJ7TlnOQ812MzeQAkzc7k6U3Oj80CAm6WdJSkE+q7shFRiBnv56GZveMOY0mSnOc6mFlAc5KzpI1Uc+wBfrHtgQ/dMbpQl9UaoMyf6p8P3FtuvHNNUqwwWfH+Wu+bR3j4wa9N39C00fTUZYhnyZKc5zqYWUBzd1bTPzcDSLplyAykYkxSrDBZ8U5SrDBZ8fZNv8b20eOK5WDlhuBcBzMLKCJiJJKc5zqYWUARESORbo0+BzMLqIHNw4sUY5JihcmKd5JihcmKd5JiXZA8oY9wiYjosnRrREQUKMk5IqJASc4jNmlTvxvE+3t1nLdLuknS6eOIs46l0QMyJT1H0rSkV7QZ34A4hsYr6WxJt0naIenv246xJ45hPwdHSvqcpG/UsTa9zzJykq6StEfSwDkDpX3Glsx2thFtVDcQ/w/wK1SLa38DOK2vzPnA31CNlX4u8LXC4/2nwNH16/PGFW+TWHvKfZHqpu0rCv+3PYpq5unJ9fvjCo71T4DL69fHAg8Aq8cU7z8DzgDumOd4MZ+xg9nSch6tg3kA5DgMjdf2TbZ/XL+9mWpM9zg0fUDmm4BPA3vaDG6AJvFeBFxr+z4A2+OKuUmsBo6QJOCJVMl5qt0w60DsG+v651PSZ2zJkpxHa75p3Yst05bFxvIGqhbJOAyNVdJa4GXAJsavyb/trwJHS/qSpFslvaa16A7UJNb3A79ONdnqm8Af2wUu5VYp6TO2ZBnnPFojnfrdgsaxSHoBVXJ+3rJGNL8msb4XuNT2dNXAG6sm8a4Cng28CDgM+Kqkm21/e7mD69Mk1pcAtwEvBJ4G3CDpy7YfWu7glqCkz9iSJTmP1qRN/W4Ui6RnAlcC59n+UUux9WsS6wbgmjoxrwHOlzRl+7p2QjxA05+FvbYfAR6RdCNwOtB2cm4S6+uBP3fVqbtT0neAU4F/aCfERSnpM7Zk6dYYrUmb+j00XkknA9cCrx5Di67X0Fhtr7N9iu1TgE8BfzSmxAzNfhY+Czxf0ipJT6Ba/fCuluOEZrHeR9XCR9LxVKu/3dtqlM2V9BlbsrScR8jLO/V7XPG+HTgG+EDdIp3yGFYoaxhrMZrEa/suSdcDtwMzwJW2W19StuG/7buAqyV9k6rb4FLbY1lGVNLHgLOBNZJ2Ae8ADumJtZjP2MHI9O2IiAKlWyMiokBJzhERBUpyjogoUJJzRESBkpwjIgqU5BwRUaAk54iIAiU5R/Sp14O+XdKhkg6v1y9+xrjjiseXBZOzpKMk/VFbwdR1Xi/pQUmfX6DML0n6eL2Y9tckndJz7LWS7qm31/bsX1eXvac+d3W9f96FuZsslh7dY3s71RTgPwXeDfy3cczci8e3YS3no4BWkzPwHuDVQ8q8Afix7acDfwFcDiDpyVRTOc+iWqP2HZKOrs+5HPgL2+uBH9fXgGoB+fX1thH4YH2tlcAV9fHTgFdJOm0U32BMhHcC51AtpvTuMccSj0PDkvOfA0+rH6PznjYCsv13wMNDil0AfLh+/SngRfUi4C8BbrD9QL1A/A3AufWxF9Zlqc99ac+1Bi3M3XRx9+imJ1MtKn8EcOiYY4nHoWELH10GPMP2swYdlPRlqh/efm+z/bcHG9wCHltMu1605SdUi/PMt8j2McCDtqf69rPAOYP2nzXabyMKthn4z8A6qr+6LhlvOPF4c1Cr0tl+/qgCWaT5FtNe7P6lXCs6rn4iyZTtj9bdWzdJeqHtL447tnj8OKjkPMaW8+xi2rskrQKOpHqm2C6qpQRnnQh8CdhL1V2xqm499y6+Pd/C3Kvn2R8dZ/sjwEfq19PkL6YYg2F9zg8zOPkCVcvZ9rMGbMuZmKG6kz47EuMVwBfrJzRsA14s6ej6RuCLgW31sf9Zl6U+97M91xq0MHeTBcgjIpbFgsm5fiTR/5J0R1s3BOvW+CepbvLtkvSSev87Jf3LuthfAcdI2gm8hapvHNsPUC0Kvr3e3lnvA7gUeEt9zjH1NaBamPteqoW5P0Q9OqVuYc8uQH4X8AnbO5btG4+I6JHF9iMiCpQZghERBUpyjogoUJJzRESBkpwjIgqU5BwRUaAk54iIAiU5R0QUKMk5IqJA/w/N0SAhWCJq5wAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
+       "<Figure size 640x480 with 2 Axes>"
       ]
      },
      "metadata": {
@@ -500,7 +492,7 @@
     {
      "data": {
       "text/plain": [
-       "<Figure size 432x288 with 0 Axes>"
+       "<Figure size 640x480 with 0 Axes>"
       ]
      },
      "metadata": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,11 @@ ignore-words-list = "pres"
 
 [tool.isort]
 known_first_party = ["pyro"]
+
+[tool.pytest.ini_options]
+# docs: symlinks to notebooks we're already testing
+# derive_analytic_solutions.ipynb: sympy derivations, doesn't use any pyro code
+addopts = """\
+  --ignore=docs/ \
+  --ignore=pyro/multigrid/derive_analytic_solutions.ipynb \
+  """


### PR DESCRIPTION
* fix some old code under `examples/mesh/experiments` that was breaking pytest discovery
* update `presentations/pyro_intro.ipynb` to the new package layout and ignore a cell that prints its run time
* move the pytest ignores to pyproject.toml

This allows us to simply run `pytest` from the repository root, and not have to pass a bunch of `--ignore` arguments.