### PR TITLE
Update requirements.txt to work with conda-forge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy>=1.13.3
 matplotlib>=2.0.0
 h5py>=2.7
 scipy>=0.16
-travis-sphinx
 sphinx_rtd_theme
 nbsphinx>=0.3.1
 pytest>=3.6
@@ -11,7 +10,7 @@ pytest-cov>=2.6.0
 flake8>=3.5.0
 numba>=0.40.0
 numpydoc
-sphinxcontrib_bibtex
+sphinxcontrib-bibtex
 sphinx-copybutton
 sphinx-prompt
 importlib-metadata


### PR DESCRIPTION
pypi normalizes underscores into hyphens, but conda-forge doesn't. travis-sphinx is no longer used.