### PR TITLE
add a DEFAULT_INPUTS to each problem setup

### DIFF
--- a/pyro/advection/problems/smooth.py
+++ b/pyro/advection/problems/smooth.py
@@ -5,7 +5,6 @@ import numpy
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.smooth"
 
 

--- a/pyro/advection/problems/smooth.py
+++ b/pyro/advection/problems/smooth.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.smooth"
+
+
 def init_data(my_data, rp):
     """ initialize the smooth advection problem """
     del rp  # this problem doesn't use runtime params

--- a/pyro/advection/problems/test.py
+++ b/pyro/advection/problems/test.py
@@ -3,6 +3,9 @@ import sys
 from pyro.mesh import patch
 
 
+DEFAULT_INPUTS = None
+
+
 def init_data(my_data, rp):
     """ an init routine for unit testing """
     del rp  # this problem doesn't use runtime params

--- a/pyro/advection/problems/test.py
+++ b/pyro/advection/problems/test.py
@@ -2,7 +2,6 @@ import sys
 
 from pyro.mesh import patch
 
-
 DEFAULT_INPUTS = None
 
 

--- a/pyro/advection/problems/tophat.py
+++ b/pyro/advection/problems/tophat.py
@@ -4,6 +4,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.tophat"
+
+
 def init_data(myd, rp):
     """ initialize the tophat advection problem """
     del rp  # this problem doesn't use runtime params

--- a/pyro/advection/problems/tophat.py
+++ b/pyro/advection/problems/tophat.py
@@ -3,7 +3,6 @@ import sys
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.tophat"
 
 

--- a/pyro/advection_fv4/problems/smooth.py
+++ b/pyro/advection_fv4/problems/smooth.py
@@ -4,6 +4,9 @@ from pyro.mesh import fv
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.smooth"
+
+
 def init_data(my_data, rp):
     """ initialize the smooth advection problem """
     del rp  # this problem doesn't use runtime params

--- a/pyro/advection_fv4/problems/smooth.py
+++ b/pyro/advection_fv4/problems/smooth.py
@@ -3,7 +3,6 @@ import numpy
 from pyro.mesh import fv
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.smooth"
 
 

--- a/pyro/advection_nonuniform/problems/slotted.py
+++ b/pyro/advection_nonuniform/problems/slotted.py
@@ -4,6 +4,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.slotted"
+
+
 def init_data(my_data, rp):
     """ initialize the slotted advection problem """
     msg.bold("initializing the slotted advection problem...")

--- a/pyro/advection_nonuniform/problems/slotted.py
+++ b/pyro/advection_nonuniform/problems/slotted.py
@@ -3,7 +3,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.slotted"
 
 

--- a/pyro/advection_nonuniform/problems/test.py
+++ b/pyro/advection_nonuniform/problems/test.py
@@ -2,6 +2,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = None
+
+
 def init_data(my_data, rp):
     """ an init routine for unit testing """
     del rp  # this problem doesn't use runtime params

--- a/pyro/advection_nonuniform/problems/test.py
+++ b/pyro/advection_nonuniform/problems/test.py
@@ -1,7 +1,6 @@
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = None
 
 

--- a/pyro/burgers/problems/converge.py
+++ b/pyro/burgers/problems/converge.py
@@ -5,7 +5,6 @@ import numpy
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.converge.64"
 
 

--- a/pyro/burgers/problems/converge.py
+++ b/pyro/burgers/problems/converge.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.converge.64"
+
+
 def init_data(my_data, rp):
     """ initialize the smooth burgers convergence problem """
     del rp  # this problem doesn't use runtime params

--- a/pyro/burgers/problems/test.py
+++ b/pyro/burgers/problems/test.py
@@ -4,6 +4,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.test"
+
+
 def init_data(myd, rp):
     """ initialize the burgers test problem """
     del rp  # this problem doesn't use runtime params

--- a/pyro/burgers/problems/test.py
+++ b/pyro/burgers/problems/test.py
@@ -3,7 +3,6 @@ import sys
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.test"
 
 

--- a/pyro/burgers/problems/tophat.py
+++ b/pyro/burgers/problems/tophat.py
@@ -3,7 +3,6 @@ import sys
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.tophat"
 
 

--- a/pyro/burgers/problems/tophat.py
+++ b/pyro/burgers/problems/tophat.py
@@ -4,6 +4,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.tophat"
+
+
 def init_data(myd, rp):
     """ initialize the tophat burgers problem """
     del rp  # this problem doesn't use runtime params

--- a/pyro/compressible/problems/acoustic_pulse.py
+++ b/pyro/compressible/problems/acoustic_pulse.py
@@ -6,6 +6,9 @@ from pyro.mesh import fv
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.acoustic_pulse"
+
+
 def init_data(myd, rp):
     """initialize the acoustic_pulse problem.  This comes from
     McCourquodale & Coella 2011"""

--- a/pyro/compressible/problems/acoustic_pulse.py
+++ b/pyro/compressible/problems/acoustic_pulse.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyro.mesh import fv
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.acoustic_pulse"
 
 

--- a/pyro/compressible/problems/advect.py
+++ b/pyro/compressible/problems/advect.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.advect.64"
+
+
 def init_data(my_data, rp):
     """ initialize a smooth advection problem for testing convergence """
 

--- a/pyro/compressible/problems/advect.py
+++ b/pyro/compressible/problems/advect.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.advect.64"
 
 

--- a/pyro/compressible/problems/bubble.py
+++ b/pyro/compressible/problems/bubble.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.bubble"
+
+
 def init_data(my_data, rp):
     """ initialize the bubble problem """
 

--- a/pyro/compressible/problems/bubble.py
+++ b/pyro/compressible/problems/bubble.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.bubble"
 
 

--- a/pyro/compressible/problems/gresho.py
+++ b/pyro/compressible/problems/gresho.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.gresho"
+
+
 def init_data(my_data, rp):
     """ initialize the Gresho vortex problem """
 

--- a/pyro/compressible/problems/gresho.py
+++ b/pyro/compressible/problems/gresho.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.gresho"
 
 

--- a/pyro/compressible/problems/hse.py
+++ b/pyro/compressible/problems/hse.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.hse"
 
 

--- a/pyro/compressible/problems/hse.py
+++ b/pyro/compressible/problems/hse.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.hse"
+
+
 def init_data(my_data, rp):
     """ initialize the HSE problem """
 

--- a/pyro/compressible/problems/kh.py
+++ b/pyro/compressible/problems/kh.py
@@ -4,6 +4,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.kh"
+
+
 def init_data(my_data, rp):
     """ initialize the Kelvin-Helmholtz problem """
 

--- a/pyro/compressible/problems/kh.py
+++ b/pyro/compressible/problems/kh.py
@@ -3,7 +3,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.kh"
 
 

--- a/pyro/compressible/problems/logo.py
+++ b/pyro/compressible/problems/logo.py
@@ -7,6 +7,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.logo"
+
+
 def init_data(my_data, rp):
     """ initialize the logo problem """
 

--- a/pyro/compressible/problems/logo.py
+++ b/pyro/compressible/problems/logo.py
@@ -6,7 +6,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.logo"
 
 

--- a/pyro/compressible/problems/quad.py
+++ b/pyro/compressible/problems/quad.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.quad"
 
 

--- a/pyro/compressible/problems/quad.py
+++ b/pyro/compressible/problems/quad.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.quad"
+
+
 def init_data(my_data, rp):
     """ initialize the quadrant problem """
 

--- a/pyro/compressible/problems/ramp.py
+++ b/pyro/compressible/problems/ramp.py
@@ -6,7 +6,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.ramp"
 
 

--- a/pyro/compressible/problems/ramp.py
+++ b/pyro/compressible/problems/ramp.py
@@ -7,6 +7,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.ramp"
+
+
 def init_data(my_data, rp):
     """ initialize the double Mach reflection problem """
 

--- a/pyro/compressible/problems/rt.py
+++ b/pyro/compressible/problems/rt.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.rt"
 
 

--- a/pyro/compressible/problems/rt.py
+++ b/pyro/compressible/problems/rt.py
@@ -6,6 +6,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.rt"
+
+
 def init_data(my_data, rp):
     """ initialize the rt problem """
 

--- a/pyro/compressible/problems/rt2.py
+++ b/pyro/compressible/problems/rt2.py
@@ -12,6 +12,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.rt2"
+
+
 def init_data(my_data, rp):
 
     """ initialize the rt problem """

--- a/pyro/compressible/problems/rt2.py
+++ b/pyro/compressible/problems/rt2.py
@@ -11,7 +11,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.rt2"
 
 

--- a/pyro/compressible/problems/sedov.py
+++ b/pyro/compressible/problems/sedov.py
@@ -7,6 +7,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.sedov"
+
+
 def init_data(my_data, rp):
     """ initialize the sedov problem """
 

--- a/pyro/compressible/problems/sedov.py
+++ b/pyro/compressible/problems/sedov.py
@@ -6,7 +6,6 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.sedov"
 
 

--- a/pyro/compressible/problems/sod.py
+++ b/pyro/compressible/problems/sod.py
@@ -4,6 +4,9 @@ from pyro.mesh import patch
 from pyro.util import msg
 
 
+DEFAULT_INPUTS = "inputs.sod.x"
+
+
 def init_data(my_data, rp):
     """ initialize the sod problem """
 

--- a/pyro/compressible/problems/sod.py
+++ b/pyro/compressible/problems/sod.py
@@ -3,7 +3,6 @@ import sys
 from pyro.mesh import patch
 from pyro.util import msg
 
-
 DEFAULT_INPUTS = "inputs.sod.x"
 
 

--- a/pyro/compressible/problems/test.py
+++ b/pyro/compressible/problems/test.py
@@ -3,6 +3,9 @@ import sys
 from pyro.mesh import patch
 
 
+DEFAULT_INPUTS = None
+
+
 def init_data(my_data, rp):
     """ an init routine for unit testing """
     del rp  # this problem doesn't use runtime params

--- a/pyro/compressible/problems/test.py
+++ b/pyro/compressible/problems/test.py
@@ -2,7 +2,6 @@ import sys
 
 from pyro.mesh import patch
 
-
 DEFAULT_INPUTS = None
 
 

--- a/pyro/compressible_react/problems/flame.py
+++ b/pyro/compressible_react/problems/flame.py
@@ -6,6 +6,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.flame"
+
 
 def init_data(my_data, rp):
     """ initialize the sedov problem """

--- a/pyro/compressible_react/problems/rt.py
+++ b/pyro/compressible_react/problems/rt.py
@@ -5,6 +5,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.rt"
+
 
 def init_data(my_data, rp):
     """ initialize the rt problem """

--- a/pyro/diffusion/problems/gaussian.py
+++ b/pyro/diffusion/problems/gaussian.py
@@ -5,6 +5,8 @@ import numpy
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.gaussian"
+
 
 def phi_analytic(dist, t, t_0, k, phi_1, phi_2):
     """ the analytic solution to the Gaussian diffusion problem """

--- a/pyro/diffusion/problems/test.py
+++ b/pyro/diffusion/problems/test.py
@@ -2,6 +2,8 @@ import sys
 
 from pyro.mesh import patch
 
+DEFAULT_INPUTS = None
+
 
 def init_data(my_data, rp):
     """ an init routine for unit testing """

--- a/pyro/incompressible/problems/converge.py
+++ b/pyro/incompressible/problems/converge.py
@@ -31,6 +31,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.converge.64"
+
 
 def init_data(my_data, rp):
     """ initialize the incompressible converge problem """

--- a/pyro/incompressible/problems/shear.py
+++ b/pyro/incompressible/problems/shear.py
@@ -21,6 +21,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.shear"
+
 
 def init_data(my_data, rp):
     """ initialize the incompressible shear problem """

--- a/pyro/incompressible_viscous/problems/cavity.py
+++ b/pyro/incompressible_viscous/problems/cavity.py
@@ -13,6 +13,8 @@ https://www.fluid.tuwien.ac.at/HendrikKuhlmann?action=AttachFile&do=get&target=L
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.cavity"
+
 
 def init_data(my_data, rp):
     """ initialize the lid-driven cavity """

--- a/pyro/incompressible_viscous/problems/converge.py
+++ b/pyro/incompressible_viscous/problems/converge.py
@@ -30,6 +30,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.converge.64"
+
 
 def init_data(my_data, rp):
     """ initialize the incompressible viscous converge problem """

--- a/pyro/incompressible_viscous/problems/shear.py
+++ b/pyro/incompressible_viscous/problems/shear.py
@@ -21,6 +21,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.shear"
+
 
 def init_data(my_data, rp):
     """ initialize the incompressible shear problem """

--- a/pyro/lm_atm/problems/bubble.py
+++ b/pyro/lm_atm/problems/bubble.py
@@ -5,6 +5,8 @@ import numpy
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.bubble"
+
 
 def init_data(my_data, base, rp):
     """ initialize the bubble problem """

--- a/pyro/lm_atm/problems/gresho.py
+++ b/pyro/lm_atm/problems/gresho.py
@@ -5,6 +5,8 @@ import numpy
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.gresho"
+
 
 def init_data(my_data, base, rp):
     """ initialize the Gresho vortex problem """

--- a/pyro/pyro_sim.py
+++ b/pyro/pyro_sim.py
@@ -112,6 +112,10 @@ class Pyro:
             self.rp.load_params(problem_defaults_file)
 
         # now read in the inputs file
+        if inputs_file is None:
+            problem = importlib.import_module("pyro.{}.problems.{}".format(self.solver_name, problem_name))
+            inputs_file = problem.DEFAULT_INPUTS
+
         if inputs_file is not None:
             if not os.path.isfile(inputs_file):
                 # check if the param file lives in the solver's problems directory
@@ -120,6 +124,7 @@ class Pyro:
                     msg.fail("ERROR: inputs file does not exist")
 
             self.rp.load_params(inputs_file, no_new=1)
+
 
         if inputs_dict is not None:
             for k, v in inputs_dict.items():

--- a/pyro/pyro_sim.py
+++ b/pyro/pyro_sim.py
@@ -125,7 +125,6 @@ class Pyro:
 
             self.rp.load_params(inputs_file, no_new=1)
 
-
         if inputs_dict is not None:
             for k, v in inputs_dict.items():
                 self.rp.params[k] = v

--- a/pyro/swe/problems/acoustic_pulse.py
+++ b/pyro/swe/problems/acoustic_pulse.py
@@ -5,6 +5,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.acoustic_pulse"
+
 
 def init_data(myd, rp):
     """initialize the acoustic_pulse problem.  This comes from

--- a/pyro/swe/problems/advect.py
+++ b/pyro/swe/problems/advect.py
@@ -5,6 +5,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.advect"
+
 
 def init_data(my_data, rp):
     """ initialize a smooth advection problem for testing convergence """

--- a/pyro/swe/problems/dam.py
+++ b/pyro/swe/problems/dam.py
@@ -3,6 +3,8 @@ import sys
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.dam.x"
+
 
 def init_data(my_data, rp):
     """ initialize the dam problem """

--- a/pyro/swe/problems/kh.py
+++ b/pyro/swe/problems/kh.py
@@ -3,6 +3,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.kh"
+
 
 def init_data(my_data, rp):
     """ initialize the Kelvin-Helmholtz problem """

--- a/pyro/swe/problems/logo.py
+++ b/pyro/swe/problems/logo.py
@@ -6,6 +6,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.logo"
+
 
 def init_data(my_data, rp):
     """ initialize the sedov problem """

--- a/pyro/swe/problems/quad.py
+++ b/pyro/swe/problems/quad.py
@@ -5,6 +5,8 @@ import numpy as np
 from pyro.mesh import patch
 from pyro.util import msg
 
+DEFAULT_INPUTS = "inputs.quad"
+
 
 def init_data(my_data, rp):
     """ initialize the quadrant problem """

--- a/pyro/swe/problems/test.py
+++ b/pyro/swe/problems/test.py
@@ -2,6 +2,8 @@ import sys
 
 from pyro.mesh import patch
 
+DEFAULT_INPTUS = None
+
 
 def init_data(my_data, rp):
     """ an init routine for unit testing """


### PR DESCRIPTION
this allows us to run a problem using the `Pyro` class without specifying an inputs file.
Now the default inputs file will be loaded, and we can override any runtime parameters
by passing in a dict.