### PR TITLE
add the riemann option to compressible_sdc

### DIFF
--- a/pyro/compressible_sdc/_defaults
+++ b/pyro/compressible_sdc/_defaults
@@ -21,5 +21,4 @@ temporal_method = RK4     ; integration method (see mesh/integration.py)
 
 grav = 0.0                ; gravitational acceleration (in y-direction)
 
-
-
+riemann = CGF


### PR DESCRIPTION
this silences a warning and will be needed once we hook in the exact Riemann solver