### PR TITLE
Fix type check when pretty printing integer data

### DIFF
--- a/pyro/mesh/array_indexer.py
+++ b/pyro/mesh/array_indexer.py
@@ -280,7 +280,7 @@ class ArrayIndexer(np.ndarray):
         """
 
         if fmt is None:
-            if isinstance(self.dtype.type, numbers.Integral):
+            if issubclass(self.dtype.type, numbers.Integral):
                 fmt = "%4d"
             elif self.dtype == np.float64:
                 fmt = "%10.5g"
@@ -498,7 +498,7 @@ class ArrayIndexerFC(ArrayIndexer):
         """
 
         if fmt is None:
-            if isinstance(self.dtype.type, numbers.Integral):
+            if issubclass(self.dtype.type, numbers.Integral):
                 fmt = "%4d"
             elif self.dtype == np.float64:
                 fmt = "%10.5g"


### PR DESCRIPTION
I found this when running `examples/mesh/bc_demo.py`.