### PR TITLE
fix how derives are imported when reading output

### DIFF
--- a/pyro/compressible/derives.py
+++ b/pyro/compressible/derives.py
@@ -57,6 +57,9 @@ def derive_primitives(myd, varnames):
         elif var == "soundspeed":
             derived_vars.append(np.sqrt(gamma*p/dens))
 
+        elif var == "machnumber":
+            derived_vars.append(np.sqrt(u**2 + v**2) / np.sqrt(gamma*p/dens))
+
         elif var == "vorticity":
             derived_vars.append(vort)
 

--- a/pyro/util/io_pyro.py
+++ b/pyro/util/io_pyro.py
@@ -127,20 +127,20 @@ def read(filename):
 
             sim.read_extras(f)
 
-        # check if there are derived variables -- since we do a lot of
-        # inheritance, we want to start with the deepest class and
-        # work backwards through the inheritance until we find a derives
-        # module
-        for mod in [cls.__module__ for cls in type(sim).__mro__ if cls is not object]:
-            try:
-                derives = importlib.import_module(f"{mod.replace('simulation', 'derives')}")
-                sim.cc_data.add_derived(derives.derive_primitives)
+            # check if there are derived variables -- since we do a lot of
+            # inheritance, we want to start with the deepest class and
+            # work backwards through the inheritance until we find a derives
+            # module
+            for mod in [cls.__module__ for cls in type(sim).__mro__ if cls is not object]:
+                try:
+                    derives = importlib.import_module(f"{mod.replace('simulation', 'derives')}")
+                    sim.cc_data.add_derived(derives.derive_primitives)
 
-            except ModuleNotFoundError:
-                continue
+                except ModuleNotFoundError:
+                    continue
 
-            else:
-                break
+                else:
+                    break
 
     if solver_name is not None:
         return sim


### PR DESCRIPTION
previously, if the solver itself did not define derives.py, then we didn't add any derived variables.  But compressible uses a lot of inheritance, and only the base compressible has derives.py. Now we loop over the inheritance hierarchy and try importing derives until we find it.

Also add machnumber to the compressible derives