### PR TITLE
optimize the compressible sdc solver

### DIFF
--- a/pyro/compressible_sdc/simulation.py
+++ b/pyro/compressible_sdc/simulation.py
@@ -3,7 +3,6 @@ using SDC time integration
 
 """
 
-
 from pyro import compressible_fv4
 from pyro.mesh import patch
 from pyro.util import msg
@@ -58,15 +57,20 @@ class Simulation(compressible_fv4.Simulation):
         U_knew.append(patch.cell_center_data_clone(self.cc_data))
         U_knew.append(patch.cell_center_data_clone(self.cc_data))
 
-        # loop over iterations
-        for _ in range(1, 5):
+        # we need the advective term at all time nodes at the old
+        # iteration -- we'll compute this for the initial state
+        # now
+        A_kold = []
+        A_kold.append(self.substep(U_kold[0]))
+        A_kold.append(A_kold[-1].copy())
+        A_kold.append(A_kold[-1].copy())
 
-            # we need the advective term at all time nodes at the old
-            # iteration -- we'll compute this now
-            A_kold = []
-            for m in range(3):
-                _tmp = self.substep(U_kold[m])
-                A_kold.append(_tmp)
+        A_knew = []
+        for adv in A_kold:
+            A_knew.append(adv.copy())
+
+        # loop over iterations
+        for _ in range(4):
 
             # loop over the time nodes and update
             for m in range(2):
@@ -74,7 +78,9 @@ class Simulation(compressible_fv4.Simulation):
                 # update m to m+1 for knew
 
                 # compute A(U_m^{k+1})
-                A_knew = self.substep(U_knew[m])
+                # note: for m = 0, the advective term doesn't change
+                if m > 0:
+                    A_knew[m] = self.substep(U_knew[m])
 
                 # compute the integral over A at the old iteration
                 integral = self.sdc_integral(m, m+1, A_kold)
@@ -82,14 +88,16 @@ class Simulation(compressible_fv4.Simulation):
                 # and the final update
                 for n in range(self.ivars.nvar):
                     U_knew[m+1].data.v(n=n)[:, :] = U_knew[m].data.v(n=n) + \
-                        0.5*self.dt * (A_knew.v(n=n) - A_kold[m].v(n=n)) + integral.v(n=n)
+                        0.5*self.dt * (A_knew[m].v(n=n) - A_kold[m].v(n=n)) + integral.v(n=n)
 
                 # fill ghost cells
                 U_knew[m+1].fill_BC_all()
 
             # store the current iteration as the old iteration
+            # node m = 0 data doesn't change
             for m in range(1, 3):
                 U_kold[m].data[:, :, :] = U_knew[m].data[:, :, :]
+                A_kold[m][...] = A_knew[m][...]
 
         # store the new solution
         self.cc_data.data[:, :, :] = U_knew[-1].data[:, :, :]


### PR DESCRIPTION
we don't need to recompute the old advective term every step we also never need to compute the advective term at m = 0 after the first time